### PR TITLE
Start building net10 preview images

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -11,7 +11,7 @@ on:
         description: 'JSON array of .NET versions to build (e.g., ["9.0", "10.0"])'
         required: false
         type: string
-        default: '["9.0"]'
+        default: '["9.0", "10.0"]'
       android_api_levels:
         description: 'JSON array of Android API levels to build (e.g., [34, 35])'
         required: false
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
     
     steps:
     - name: 🛒 Checkout
@@ -92,7 +92,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
     
     steps:
     - name: 🛒 Checkout
@@ -142,7 +142,7 @@ jobs:
     needs: build-base-windows
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
     
     steps:
     - name: 🛒 Checkout
@@ -192,7 +192,7 @@ jobs:
     needs: build-base-linux
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
     
     steps:
     - name: 🛒 Checkout
@@ -273,7 +273,7 @@ jobs:
         $dotnetVersions = if ($dotnetVersionsInput -ne "") {
           $dotnetVersionsInput | ConvertFrom-Json
         } else {
-          @("9.0")
+          @("9.0", "10.0")
         }
         $workloadApiLevels = @{}
         
@@ -307,7 +307,7 @@ jobs:
         $dotnetVersions = if ($dotnetVersionsInput -ne "") {
           $dotnetVersionsInput | ConvertFrom-Json
         } else {
-          @("9.0")
+          @("9.0", "10.0")
         }
         
         # Define API levels to use

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
 
     steps:
     - name: 🛒 Checkout
@@ -71,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
 
     steps:
     - name: 🛒 Checkout

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
 
     steps:
     - name: 🛒 Checkout
@@ -75,7 +75,7 @@ jobs:
 
     strategy:
       matrix:
-        DOTNET_VERSION: [ "9.0" ]
+        DOTNET_VERSION: [ "9.0", "10.0" ]
 
     steps:
     - name: 🛒 Checkout


### PR DESCRIPTION
This pull request updates the build and workload set logic to support both .NET 9.0 and 10.0 versions, and improves the way the latest workload set is detected, especially regarding prerelease versions. The changes ensure that all GitHub Actions workflows build against both .NET 9.0 and 10.0, and enhance the PowerShell scripts to automatically detect and include prerelease workload sets when stable versions are not available.

Key changes include:

**Build matrix and workflow updates:**

* All GitHub Actions workflow files (`build-all.yml`, `build-base.yml`, `build-runner.yml`) now build against both .NET 9.0 and 10.0 by updating the `DOTNET_VERSION` matrix and relevant defaults. [[1]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L14-R14) [[2]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L48-R48) [[3]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L95-R95) [[4]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L145-R145) [[5]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L195-R195) [[6]](diffhunk://#diff-805f6e337778b35e16e769aafa18aa6c4cbf0ed0cbee0c527e205db33cd169aeL23-R23) [[7]](diffhunk://#diff-805f6e337778b35e16e769aafa18aa6c4cbf0ed0cbee0c527e205db33cd169aeL74-R74) [[8]](diffhunk://#diff-8290b76c2699af63fbfedc6a86817370fa6d2e5b32a6e265dad20c9463bc9b70L23-R23) [[9]](diffhunk://#diff-8290b76c2699af63fbfedc6a86817370fa6d2e5b32a6e265dad20c9463bc9b70L78-R78) [[10]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L276-R276) [[11]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L310-R310)

**Workload set detection improvements in PowerShell scripts:**

* The `Find-LatestWorkloadSet` function in `common-functions.ps1` now includes parameters for prerelease handling and can auto-detect when to include prerelease workload sets if no stable versions are found. The function searches NuGet endpoints for stable versions first, and only includes prereleases if necessary. [[1]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abL7-R9) [[2]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abR23-R68) [[3]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abL37-R103)
* The regex used to match workload set package IDs has been updated to support both stable and prerelease patterns, ensuring correct detection for .NET 10 and future versions. [[1]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abL37-R103) [[2]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abL93-R145)
* The `Get-WorkloadSetInfo` function now passes the new prerelease parameters to `Find-LatestWorkloadSet`, enabling consistent prerelease handling throughout the script. [[1]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abL381-R433) [[2]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abL392-R444) [[3]](diffhunk://#diff-7e9edd012d3505bc8dd755af7c81fba5666fd219311e06262c320034942658abL403-R455)