### PR TITLE
Refactor Tart image naming and cleanup in CI build

### DIFF
--- a/.github/workflows/build-tart-vms.yml
+++ b/.github/workflows/build-tart-vms.yml
@@ -76,6 +76,10 @@ jobs:
         echo "Cleaning up existing Tart images..."
         tart list || true
 
+        # Remove CI build image if it exists from previous builds
+        echo "Removing maui-macos-ci image if it exists..."
+        tart delete maui-macos-ci 2>&1 || echo "  (image not found, skipping)"
+
         # Remove any existing build artifacts to free up space
         brew cleanup || true
 
@@ -98,8 +102,10 @@ jobs:
         Write-Host ""
 
         $buildArgs = @{
-          ImageType     = "${{ env.IMAGE_TYPE }}"
-          DotnetChannel = "${{ env.DOTNET_CHANNEL }}"
+          ImageType         = "${{ env.IMAGE_TYPE }}"
+          DotnetChannel     = "${{ env.DOTNET_CHANNEL }}"
+          ImageName         = "maui-macos-ci"
+          RegistryImageName = "maui-macos"
         }
 
         # Add workload set version if specified
@@ -110,9 +116,7 @@ jobs:
           Write-Host "No workload set version specified - will auto-detect latest"
         }
 
-        if ("${{ inputs.force_build }}" -eq "true") {
-          $buildArgs.Force = $true
-        }
+        # Note: -Force is not needed since we delete maui-macos-ci before building
 
         # Determine if we should push to registry
         $shouldPush = $false
@@ -205,23 +209,9 @@ jobs:
         Write-Host "Images before cleanup:"
         tart list
 
-        # Get the expected image name based on platform matrix
-        $matrixFile = "tart/macos/config/platform-matrix.json"
-        if (Test-Path $matrixFile) {
-          $matrix = Get-Content $matrixFile -Raw | ConvertFrom-Json
-          $channelInfo = $matrix.DotnetChannels."${{ env.DOTNET_CHANNEL }}"
-          if ($channelInfo -and $channelInfo.MacOSVersion) {
-            $macosVersion = $channelInfo.MacOSVersion
-            $imageName = "maui-$macosVersion"
-
-            Write-Host "Removing local image: $imageName"
-            tart delete $imageName 2>&1 | Out-Null || Write-Host "  (image not found, skipping)"
-          }
-        }
-
-        # Also try the generic name
-        Write-Host "Removing local image: maui-macos"
-        tart delete maui-macos 2>&1 | Out-Null || Write-Host "  (image not found, skipping)"
+        # Remove the CI build image
+        Write-Host "Removing local image: maui-macos-ci"
+        tart delete maui-macos-ci 2>&1 | Out-Null || Write-Host "  (image not found, skipping)"
 
         Write-Host ""
         Write-Host "Images after cleanup:"


### PR DESCRIPTION
Standardizes the use of 'maui-macos-ci' as the CI build image name in the GitHub workflow and PowerShell build script. Updates image cleanup logic to remove only the CI build image, and refactors registry tagging to use a separate RegistryImageName parameter for clarity and consistency.