### PR TITLE
Add explicit Tart registry login step to workflow

### DIFF
--- a/.github/workflows/build-tart-vms.yml
+++ b/.github/workflows/build-tart-vms.yml
@@ -86,12 +86,16 @@ jobs:
         echo "Disk space after cleanup:"
         df -h
 
+    - name: 🔐 Login to Registry
+      if: github.ref == 'refs/heads/main' || inputs.push_to_registry == true
+      run: |
+        echo "Logging in to Tart registry..."
+        echo "${{ secrets.GITHUB_TOKEN }}" | tart login ghcr.io --username "${{ github.actor }}" --password-stdin
+        echo "Login successful"
+
     - name: 🔧 Build Tart VM Image
       shell: pwsh
       env:
-        # Tart uses these environment variables for OCI registry authentication
-        TART_REGISTRY_USERNAME: ${{ github.actor }}
-        TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         # Packer uses this to authenticate GitHub API requests for plugin downloads
         PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
Introduces a dedicated step for logging into the Tart registry using GitHub credentials before building VM images. This replaces the previous use of environment variables for registry authentication, improving clarity and reliability of the authentication process.