### PR TITLE
Add Git SHA and Xcode version to build tags

### DIFF
--- a/.github/workflows/build-docker-linux.yml
+++ b/.github/workflows/build-docker-linux.yml
@@ -44,6 +44,11 @@ jobs:
         echo "workload_set_version=$WORKLOAD_SET_VERSION" >> $GITHUB_OUTPUT
         echo "Using workload set version: $WORKLOAD_SET_VERSION"
 
+        # Get short Git SHA for unique build tagging
+        BUILD_SHA=$(git rev-parse --short=8 HEAD)
+        echo "build_sha=$BUILD_SHA" >> $GITHUB_OUTPUT
+        echo "Build SHA: $BUILD_SHA"
+
     - name: 🐋 Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -59,6 +64,7 @@ jobs:
           DotNetVersion     = "${{ matrix.DOTNET_VERSION }}"
           Version           = "${{ github.run_id }}"
           DockerPlatform    = "linux/amd64"
+          BuildSha          = "${{ steps.vars.outputs.build_sha }}"
           Load              = $true
         }
         if ("${{ github.ref }}" -eq "refs/heads/main") {

--- a/.github/workflows/build-docker-windows.yml
+++ b/.github/workflows/build-docker-windows.yml
@@ -44,6 +44,11 @@ jobs:
         echo "workload_set_version=$env:WORKLOAD_SET_VERSION" >> $env:GITHUB_OUTPUT
         Write-Host "Using workload set version: $env:WORKLOAD_SET_VERSION"
 
+        # Get short Git SHA for unique build tagging
+        $BUILD_SHA = git rev-parse --short=8 HEAD
+        echo "build_sha=$BUILD_SHA" >> $env:GITHUB_OUTPUT
+        Write-Host "Build SHA: $BUILD_SHA"
+
     - name: 🐋 Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -59,6 +64,7 @@ jobs:
           DotNetVersion     = "${{ matrix.DOTNET_VERSION }}"
           Version           = "${{ github.run_id }}"
           DockerPlatform    = "windows/amd64"
+          BuildSha          = "${{ steps.vars.outputs.build_sha }}"
           Load              = $true
         }
 

--- a/.github/workflows/build-emulators.yml
+++ b/.github/workflows/build-emulators.yml
@@ -178,10 +178,16 @@ jobs:
       shell: pwsh
       working-directory: ./docker/test/
       run: |
+        # Get short Git SHA for unique build tagging
+        $buildSha = git rev-parse --short=8 HEAD
+        Write-Host "Build SHA: $buildSha"
+        Write-Host ""
+
         # Build arguments
         $buildArgs = @{
           AndroidSdkApiLevel  = "${{ matrix.android_api_level }}"
           Version             = "${{ github.run_id }}"
+          BuildSha            = $buildSha
           Load                = $true
         }
 

--- a/.github/workflows/build-tart-vms.yml
+++ b/.github/workflows/build-tart-vms.yml
@@ -107,11 +107,17 @@ jobs:
         Write-Host "Workload Set Version: ${{ env.WORKLOAD_SET_VERSION }}"
         Write-Host ""
 
+        # Get short Git SHA for unique build tagging
+        $buildSha = git rev-parse --short=8 HEAD
+        Write-Host "Build SHA: $buildSha"
+        Write-Host ""
+
         $buildArgs = @{
           ImageType         = "${{ env.IMAGE_TYPE }}"
           DotnetChannel     = "${{ env.DOTNET_CHANNEL }}"
           ImageName         = "maui-macos-ci-dotnet${{ env.DOTNET_CHANNEL }}"
           RegistryImageName = "maui-macos"
+          BuildSha          = $buildSha
         }
 
         # Add workload set version if specified


### PR DESCRIPTION
Workflows now capture a short Git SHA for unique build tagging and pass it to build scripts. The Tart macOS build script supports new tag formats including Xcode version, workload set version, and SHA, improving traceability and reproducibility of published images.