### PR TITLE
Update macOS platform matrix for Tahoe version

### DIFF
--- a/tart/macos/config/platform-matrix.json
+++ b/tart/macos/config/platform-matrix.json
@@ -1,14 +1,9 @@
 {
     "MacOSVersions": {
-        "sequoia": {
-            "FullName": "macOS Sequoia 15",
-            "MinXcodeVersion": "16.0",
-            "RecommendedXcodeVersion": "16.4"
-        },
         "tahoe": {
             "FullName": "macOS Tahoe 16",
-            "MinXcodeVersion": "26.0",
-            "RecommendedXcodeVersion": "26"
+            "MinXcodeVersion": "26.1",
+            "RecommendedXcodeVersion": "26.1.1"
         }
     },
     "DotnetChannels": {
@@ -16,9 +11,9 @@
             "Channel": "9.0",
             "LTS": false,
             "MacOSVersion": "tahoe",
-            "BaseXcodeVersion": "26.1",
+            "BaseXcodeVersion": "26.1.1",
             "AdditionalXcodeVersions": [],
-            "MinMacOSVersion": "sequoia",
+            "MinMacOSVersion": "tahoe",
             "SupportedWorkloads": [
                 "maui",
                 "android",
@@ -32,9 +27,9 @@
             "Channel": "10.0",
             "LTS": false,
             "MacOSVersion": "tahoe",
-            "BaseXcodeVersion": "26.1",
+            "BaseXcodeVersion": "26.1.1",
             "AdditionalXcodeVersions": [],
-            "MinMacOSVersion": "sequoia",
+            "MinMacOSVersion": "tahoe",
             "SupportedWorkloads": [
                 "maui",
                 "android",
@@ -43,7 +38,7 @@
                 "tvos",
                 "macos"
             ],
-            "IsPreview": true
+            "IsPreview": false
         }
     }
 }


### PR DESCRIPTION
This pull request updates the macOS platform matrix configuration to align with the latest supported versions for Xcode and macOS, and adjusts the preview status for .NET channels. The most important changes are grouped below:

Platform and Version Updates:

* Removed the `sequoia` macOS version and updated all references to use `tahoe` as the minimum and current supported macOS version.
* Updated `tahoe` to require `Xcode 26.1` as the minimum version and `Xcode 26.1.1` as the recommended version.
* Changed `.NET 9.0` and `.NET 10.0` channels to use `Xcode 26.1.1` as their base version, and set their minimum macOS version to `tahoe`. [[1]](diffhunk://#diff-f128de5190511969f7d4e05e1b4c63bc2e6d86300e74148697185a5ea45d56bbL3-R16) [[2]](diffhunk://#diff-f128de5190511969f7d4e05e1b4c63bc2e6d86300e74148697185a5ea45d56bbL35-R32)

Preview Status Adjustment:

* Set the `.NET 10.0` channel's `IsPreview` flag to `false`, indicating it is no longer considered a preview release.