### PR TITLE
Fix tart push auth failure due to Keychain locking during builds

### DIFF
--- a/.github/workflows/build-tart-vms.yml
+++ b/.github/workflows/build-tart-vms.yml
@@ -106,6 +106,11 @@ jobs:
       env:
         # Packer uses this to authenticate GitHub API requests for plugin downloads
         PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Tart registry credentials for re-authentication before push
+        # (macOS Keychain may lock during long Packer builds)
+        TART_REGISTRY_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        TART_REGISTRY_USERNAME: ${{ github.actor }}
+        CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
       run: |
         Write-Host "=== Build Configuration ==="
         Write-Host ".NET Channel: ${{ env.DOTNET_CHANNEL }}"

--- a/tart/macos/scripts/build.ps1
+++ b/tart/macos/scripts/build.ps1
@@ -438,6 +438,26 @@ function Push-TartImage {
         return
     }
 
+    # Re-authenticate to registry before pushing.
+    # The macOS Keychain may lock during long Packer builds, causing tart push
+    # to fail with errSecInteractionNotAllowed (-25308). Re-running tart login
+    # right before push ensures fresh, accessible credentials.
+    $registryHost = ($Registry -split '/')[0]
+    if ($env:TART_REGISTRY_TOKEN) {
+        Write-Host "Re-authenticating to $registryHost before push..."
+        if ($env:CI_KEYCHAIN_PASSWORD) {
+            & security unlock-keychain -p $env:CI_KEYCHAIN_PASSWORD ~/Library/Keychains/login.keychain-db 2>&1 | Out-Null
+            & security set-keychain-settings ~/Library/Keychains/login.keychain-db 2>&1 | Out-Null
+        }
+        $loginUsername = if ($env:TART_REGISTRY_USERNAME) { $env:TART_REGISTRY_USERNAME } else { "token" }
+        $env:TART_REGISTRY_TOKEN | & tart login $registryHost --username $loginUsername --password-stdin
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to re-authenticate to $registryHost - push may fail"
+        } else {
+            Write-Host "Re-authentication successful"
+        }
+    }
+
     Write-Host "Pushing image to registry with multiple tags..."
     $pushCount = 0
     foreach ($tag in $tags) {


### PR DESCRIPTION
## Problem

`tart push` fails with 401 Unauthorized after the Packer build completes:

```
Failed to retrieve credentials using Keychain credentials provider, authentication may fail: 
  Failed(message: "Keychain returned unsuccessful status -25308")
Error: UnexpectedHTTPStatusCode(when: "pushing blob (POST)", code: 401, 
  details: "unauthenticated: User cannot be authenticated with the token provided.")
```

The macOS Keychain locks during the ~10 minute Packer build, making the credentials stored by `tart login` in the earlier workflow step inaccessible (`-25308` = `errSecInteractionNotAllowed`).

## Fix

Re-authenticate to the registry **right before pushing** in `Push-TartImage`:

1. **Workflow**: Pass `GHCR_TOKEN`, `GITHUB_ACTOR`, and `CI_KEYCHAIN_PASSWORD` as env vars to the build step
2. **Build script**: Before the push loop, unlock the Keychain and re-run `tart login` if credentials are available

This ensures fresh, accessible credentials regardless of how long the Packer build takes.

## Related

- Failed run: https://github.com/maui-containers/maui-containers/actions/runs/23818671735/job/69425017008