### PR TITLE
Fix Keychain ACL blocking tart push in CI

### DIFF
--- a/.github/workflows/build-tart-vms.yml
+++ b/.github/workflows/build-tart-vms.yml
@@ -99,6 +99,10 @@ jobs:
         security set-keychain-settings ~/Library/Keychains/login.keychain-db
         echo "Logging in to GitHub via Tart..."
         echo "${{ secrets.GHCR_TOKEN }}" | tart login ghcr.io --username "${{ github.actor }}" --password-stdin
+        # Allow non-interactive access to keychain items in CI
+        # Without this, tart push gets errSecInteractionNotAllowed (-25308)
+        # because the keychain item ACL requires a confirmation dialog
+        security set-key-partition-list -S apple-tool:,apple: -s -k "${{ secrets.CI_KEYCHAIN_PASSWORD }}" ~/Library/Keychains/login.keychain-db
         echo "Login successful"
 
     - name: 🔧 Build Tart VM Image

--- a/tart/macos/scripts/build.ps1
+++ b/tart/macos/scripts/build.ps1
@@ -439,15 +439,17 @@ function Push-TartImage {
     }
 
     # Re-authenticate to registry before pushing.
-    # The macOS Keychain may lock during long Packer builds, causing tart push
-    # to fail with errSecInteractionNotAllowed (-25308). Re-running tart login
-    # right before push ensures fresh, accessible credentials.
+    # The macOS Keychain item ACL requires a confirmation dialog by default,
+    # which fails in CI with errSecInteractionNotAllowed (-25308).
+    # We unlock the keychain, re-login, then update the partition list to allow
+    # non-interactive access so tart push can read the stored credentials.
+    $keychainPath = "$HOME/Library/Keychains/login.keychain-db"
     $registryHost = ($Registry -split '/')[0]
     if ($env:TART_REGISTRY_TOKEN) {
         Write-Host "Re-authenticating to $registryHost before push..."
         if ($env:CI_KEYCHAIN_PASSWORD) {
-            & security unlock-keychain -p $env:CI_KEYCHAIN_PASSWORD ~/Library/Keychains/login.keychain-db 2>&1 | Out-Null
-            & security set-keychain-settings ~/Library/Keychains/login.keychain-db 2>&1 | Out-Null
+            & security unlock-keychain -p $env:CI_KEYCHAIN_PASSWORD $keychainPath 2>&1 | Out-Null
+            & security set-keychain-settings $keychainPath 2>&1 | Out-Null
         }
         $loginUsername = if ($env:TART_REGISTRY_USERNAME) { $env:TART_REGISTRY_USERNAME } else { "token" }
         $env:TART_REGISTRY_TOKEN | & tart login $registryHost --username $loginUsername --password-stdin
@@ -455,6 +457,10 @@ function Push-TartImage {
             Write-Warning "Failed to re-authenticate to $registryHost - push may fail"
         } else {
             Write-Host "Re-authentication successful"
+        }
+        # Update keychain partition list to allow non-interactive access
+        if ($env:CI_KEYCHAIN_PASSWORD) {
+            & security set-key-partition-list -S "apple-tool:,apple:" -s -k $env:CI_KEYCHAIN_PASSWORD $keychainPath 2>&1 | Out-Null
         }
     }
 


### PR DESCRIPTION
The -25308 (errSecInteractionNotAllowed) error occurs because Keychain items created by tart login have an ACL that requires a UI confirmation dialog, which cannot display in CI. The tart login succeeds (writing), but tart push fails (reading requires the dialog).

Add security set-key-partition-list after tart login in both the workflow login step and the build script re-auth to allow non-interactive access to Keychain items. Also use $HOME instead of ~ in PowerShell for reliable path resolution.