### PR TITLE
Use Tart env var auth instead of Keychain for CI push

### DIFF
--- a/.github/workflows/build-tart-vms.yml
+++ b/.github/workflows/build-tart-vms.yml
@@ -90,31 +90,17 @@ jobs:
         echo "Disk space after cleanup:"
         df -h
 
-    - name: 🔐 Login to GitHub Container Registry
-      if: github.ref == 'refs/heads/main' || inputs.push_to_registry == true
-      run: |
-        echo "Unlocking keychain..."
-        security unlock-keychain -p ${{ secrets.CI_KEYCHAIN_PASSWORD }} ~/Library/Keychains/login.keychain-db
-        # Prevent keychain from auto-locking during long Packer builds
-        security set-keychain-settings ~/Library/Keychains/login.keychain-db
-        echo "Logging in to GitHub via Tart..."
-        echo "${{ secrets.GHCR_TOKEN }}" | tart login ghcr.io --username "${{ github.actor }}" --password-stdin
-        # Allow non-interactive access to keychain items in CI
-        # Without this, tart push gets errSecInteractionNotAllowed (-25308)
-        # because the keychain item ACL requires a confirmation dialog
-        security set-key-partition-list -S apple-tool:,apple: -s -k "${{ secrets.CI_KEYCHAIN_PASSWORD }}" ~/Library/Keychains/login.keychain-db
-        echo "Login successful"
-
     - name: 🔧 Build Tart VM Image
       shell: pwsh
       env:
         # Packer uses this to authenticate GitHub API requests for plugin downloads
         PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Tart registry credentials for re-authentication before push
-        # (macOS Keychain may lock during long Packer builds)
-        TART_REGISTRY_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        # Tart registry credentials via env vars (bypasses macOS Keychain entirely).
+        # Tart 2.32.0 changed its code signing which broke Keychain-based auth in CI.
+        # These env vars are the officially recommended approach for CI:
+        # https://tart.run/quick-start/#registry-authorization
         TART_REGISTRY_USERNAME: ${{ github.actor }}
-        CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
+        TART_REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
       run: |
         Write-Host "=== Build Configuration ==="
         Write-Host ".NET Channel: ${{ env.DOTNET_CHANNEL }}"

--- a/tart/macos/scripts/build.ps1
+++ b/tart/macos/scripts/build.ps1
@@ -438,32 +438,6 @@ function Push-TartImage {
         return
     }
 
-    # Re-authenticate to registry before pushing.
-    # The macOS Keychain item ACL requires a confirmation dialog by default,
-    # which fails in CI with errSecInteractionNotAllowed (-25308).
-    # We unlock the keychain, re-login, then update the partition list to allow
-    # non-interactive access so tart push can read the stored credentials.
-    $keychainPath = "$HOME/Library/Keychains/login.keychain-db"
-    $registryHost = ($Registry -split '/')[0]
-    if ($env:TART_REGISTRY_TOKEN) {
-        Write-Host "Re-authenticating to $registryHost before push..."
-        if ($env:CI_KEYCHAIN_PASSWORD) {
-            & security unlock-keychain -p $env:CI_KEYCHAIN_PASSWORD $keychainPath 2>&1 | Out-Null
-            & security set-keychain-settings $keychainPath 2>&1 | Out-Null
-        }
-        $loginUsername = if ($env:TART_REGISTRY_USERNAME) { $env:TART_REGISTRY_USERNAME } else { "token" }
-        $env:TART_REGISTRY_TOKEN | & tart login $registryHost --username $loginUsername --password-stdin
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "Failed to re-authenticate to $registryHost - push may fail"
-        } else {
-            Write-Host "Re-authentication successful"
-        }
-        # Update keychain partition list to allow non-interactive access
-        if ($env:CI_KEYCHAIN_PASSWORD) {
-            & security set-key-partition-list -S "apple-tool:,apple:" -s -k $env:CI_KEYCHAIN_PASSWORD $keychainPath 2>&1 | Out-Null
-        }
-    }
-
     Write-Host "Pushing image to registry with multiple tags..."
     $pushCount = 0
     foreach ($tag in $tags) {


### PR DESCRIPTION
Tart 2.32.0 (PR cirruslabs/tart#1216) changed its code signing to sign the whole app bundle. This broke Keychain-based auth in CI because the new signature changes the Keychain item ACLs, causing -25308 (errSecInteractionNotAllowed) on every tart push.

Replace all Keychain manipulation (unlock, tart login, set-key-partition-list) with TART_REGISTRY_USERNAME and TART_REGISTRY_PASSWORD env vars, which is Tart's officially recommended approach for CI:
https://tart.run/quick-start/#registry-authorization

This is both simpler and immune to future code signing changes.