### PR TITLE
Add rolling workload band tags for published images

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ Images are published under the `maui-containers` organization:
 
 All images use a consistent tag format with platform/OS identifiers and version information:
 
-**Pattern:** `{platform-identifier}-dotnet{X.Y}-workloads{X.Y.Z}[-v{sha}]`
+**Pattern:** `{platform-identifier}-dotnet{X.Y}-workloads{exact-or-band}[-v{sha}]`
 
 **Tag Variants:**
 
 1. **`{platform}-dotnet{X.Y}`** - Latest workload set for this .NET version
 2. **`{platform}-dotnet{X.Y}-workloads{X.Y.Z}`** - Specific workload version
-3. **`{platform}-dotnet{X.Y}-workloads{X.Y.Z}-v{sha}`** - SHA-pinned build (optional)
+3. **`{platform}-dotnet{X.Y}-workloads{X.Y.Nxx}`** - Rolling workload-band tag for minor updates in a hundreds range
+4. **`{platform}-dotnet{X.Y}-workloads{X.Y.Z}-v{sha}`** - SHA-pinned build (optional)
 
 ### Examples by Platform
 
@@ -75,11 +76,13 @@ All images use a consistent tag format with platform/OS identifiers and version 
 # .NET 10.0
 maui-containers/maui-linux:dotnet10.0
 maui-containers/maui-linux:dotnet10.0-workloads10.0.100-rc.2.25024.3
+maui-containers/maui-linux:dotnet10.0-workloads10.0.1xx
 maui-containers/maui-linux:dotnet10.0-workloads10.0.100-rc.2.25024.3-vsha256abc
 
 # .NET 9.0
 maui-containers/maui-linux:dotnet9.0
 maui-containers/maui-linux:dotnet9.0-workloads9.0.305
+maui-containers/maui-linux:dotnet9.0-workloads9.0.3xx
 maui-containers/maui-linux:dotnet9.0-workloads9.0.305-vsha256abc
 ```
 
@@ -101,11 +104,13 @@ maui-containers/maui-windows:dotnet9.0-workloads9.0.305-vsha256abc
 # .NET 10.0
 maui-containers/maui-macos:tahoe-dotnet10.0
 maui-containers/maui-macos:tahoe-dotnet10.0-workloads10.0.100-rc.2.25024.3
+maui-containers/maui-macos:tahoe-dotnet10.0-workloads10.0.1xx
 maui-containers/maui-macos:tahoe-dotnet10.0-workloads10.0.100-rc.2.25024.3-vsha256abc
 
 # .NET 9.0
 maui-containers/maui-macos:tahoe-dotnet9.0
 maui-containers/maui-macos:tahoe-dotnet9.0-workloads9.0.305
+maui-containers/maui-macos:tahoe-dotnet9.0-workloads9.0.3xx
 maui-containers/maui-macos:tahoe-dotnet9.0-workloads9.0.305-vsha256abc
 ```
 
@@ -133,6 +138,7 @@ maui-containers/maui-emulator-linux:android34-dotnet9.0-workloads9.0.305
 
 - **Always includes .NET version** - No ambiguity about which .NET version is installed
 - **Workload versions explicit** - Pin to specific workload sets for reproducible builds
+- **Rolling band tags available** - Follow updates like `10.0.2xx` or `9.0.3xx` without jumping across bands
 - **SHA pinning optional** - For maximum reproducibility when needed
 - **Platform-aware** - macOS includes OS version for Xcode; emulator includes API level
 - **No redundant tags** - Removed ambiguous `:latest` and platform-only tags
@@ -319,8 +325,10 @@ Tart VM images provide complete macOS virtual machines for .NET MAUI development
 **Available Tags:**
 - `tahoe-dotnet10.0` - .NET 10.0 on macOS Tahoe
 - `tahoe-dotnet10.0-workloads10.0.100-rc.2.25024.3` - Specific workload version
+- `tahoe-dotnet10.0-workloads10.0.1xx` - Rolling tag for the 10.0.100-199 workload band
 - `tahoe-dotnet9.0` - .NET 9.0 on macOS Tahoe
 - `tahoe-dotnet9.0-workloads9.0.305` - Specific workload version
+- `tahoe-dotnet9.0-workloads9.0.3xx` - Rolling tag for the 9.0.300-399 workload band
 
 Images are automatically built and published to GitHub Container Registry (ghcr.io) when workload updates are detected or when manually triggered.
 

--- a/common-functions.ps1
+++ b/common-functions.ps1
@@ -357,6 +357,38 @@ function Convert-ToWorkloadVersion {
     }
 }
 
+# Derive a rolling workload band tag alias from a resolved workload version.
+# Examples:
+#   10.0.201 -> 10.0.2xx
+#   9.0.305  -> 9.0.3xx
+#   10.0.100-rc.1.12345.6 -> 10.0.1xx
+function Get-WorkloadBandTag {
+    param (
+        [string]$WorkloadVersion
+    )
+
+    if ([string]::IsNullOrWhiteSpace($WorkloadVersion)) {
+        return $null
+    }
+
+    if ($WorkloadVersion -notmatch '^(?<major>\d+)\.(?<minor>\d+)\.(?<band>\d{3,})(?:[.+-].*)?$') {
+        Write-Verbose "Could not derive workload band tag from version '$WorkloadVersion'."
+        return $null
+    }
+
+    $majorVersion = $Matches['major']
+    $minorVersion = $Matches['minor']
+    $bandNumber = [int]$Matches['band']
+
+    if ($bandNumber -lt 100) {
+        Write-Verbose "Workload band '$bandNumber' is not in a supported hundreds range."
+        return $null
+    }
+
+    $bandAlias = "$([math]::Floor($bandNumber / 100))xx"
+    return "$majorVersion.$minorVersion.$bandAlias"
+}
+
 # Helper function to convert base version from NuGet to CLI format
 function Convert-BaseVersionToCliFormat {
     param (

--- a/docker/build.ps1
+++ b/docker/build.ps1
@@ -87,9 +87,11 @@ Write-Host "Using build context: $contextPath"
 # Build tags following the unified naming scheme:
 # - dotnet{X.Y} - Latest workload for this .NET version
 # - dotnet{X.Y}-workloads{X.Y.Z} - Specific workload version
+# - dotnet{X.Y}-workloads{X.Y.Nxx} - Rolling workload band alias (e.g. 10.0.2xx)
 # - dotnet{X.Y}-workloads{X.Y.Z}-v{sha} - SHA-pinned version (optional)
 # If Version is not "latest", also add a custom version tag
 $tags = @()
+$workloadBandTagVersion = Get-WorkloadBandTag -WorkloadVersion $dotnetCommandWorkloadSetVersion
 
 # 1. dotnet{X.Y} tag (this is the "latest" for this .NET version)
 $dotnetTag = "$DockerRepository`:dotnet$DotnetVersion"
@@ -99,13 +101,21 @@ $tags += $dotnetTag
 $workloadTag = "$DockerRepository`:dotnet$DotnetVersion-workloads$dotnetCommandWorkloadSetVersion"
 $tags += $workloadTag
 
-# 3. Optional: dotnet{X.Y}-workloads{X.Y.Z}-v{sha} tag
+# 3. Optional: dotnet{X.Y}-workloads{X.Y.Nxx} rolling band tag
+if ($workloadBandTagVersion) {
+    $workloadBandTag = "$DockerRepository`:dotnet$DotnetVersion-workloads$workloadBandTagVersion"
+    if ($tags -notcontains $workloadBandTag) {
+        $tags += $workloadBandTag
+    }
+}
+
+# 4. Optional: dotnet{X.Y}-workloads{X.Y.Z}-v{sha} tag
 if ($BuildSha) {
     $shaTag = "$DockerRepository`:dotnet$DotnetVersion-workloads$dotnetCommandWorkloadSetVersion-v$BuildSha"
     $tags += $shaTag
 }
 
-# 4. Optional: Custom version tag (for PR builds, etc.)
+# 5. Optional: Custom version tag (for PR builds, etc.)
 if ($Version -ne "latest") {
     $customTag = "$DockerRepository`:dotnet$DotnetVersion-$Version"
     $tags += $customTag

--- a/tart/macos/scripts/build.ps1
+++ b/tart/macos/scripts/build.ps1
@@ -376,6 +376,7 @@ function Push-TartImage {
     # :{macos}-dotnet{version} (always - this is the "latest" for this .NET version)
     # :{macos}-dotnet{version}-xcode{version} (if Xcode version known)
     # :{macos}-dotnet{version}-xcode{version}-workloads{workloadversion} (if both known)
+    # :{macos}-dotnet{version}-xcode{version}-workloads{band}xx (rolling workload band alias)
     # :{macos}-dotnet{version}-xcode{version}-workloads{workloadversion}-v{sha} (if SHA provided)
     $tags = @()
 
@@ -399,6 +400,8 @@ function Push-TartImage {
         }
     }
 
+    $workloadBandTagVersion = Get-WorkloadBandTag -WorkloadVersion $WorkloadSetVersion
+
     # 1. macOS + .NET version tag (e.g., :tahoe-dotnet10.0) - this is the "latest" for this .NET version
     $baseTag = "$MacOSVersion-dotnet$DotnetChannel"
     $tags += "$Registry/${registryName}:$baseTag"
@@ -413,6 +416,14 @@ function Push-TartImage {
             $fullTag = "$xcodeTag-workloads$WorkloadSetVersion"
             $tags += "$Registry/${registryName}:$fullTag"
 
+            if ($workloadBandTagVersion) {
+                $bandTag = "$xcodeTag-workloads$workloadBandTagVersion"
+                $bandTagRef = "$Registry/${registryName}:$bandTag"
+                if ($tags -notcontains $bandTagRef) {
+                    $tags += $bandTagRef
+                }
+            }
+
             # 4. Add SHA-pinned tag if BuildSha is provided (e.g., :tahoe-dotnet10.0-xcode26.1-workloads10.0.100.1-vabc12345)
             if ($BuildSha) {
                 $shaTag = "$fullTag-v$BuildSha"
@@ -423,6 +434,14 @@ function Push-TartImage {
         # Fallback: If no Xcode version tag but we have workloads, use old format
         $workloadTag = "$MacOSVersion-dotnet$DotnetChannel-workloads$WorkloadSetVersion"
         $tags += "$Registry/${registryName}:$workloadTag"
+
+        if ($workloadBandTagVersion) {
+            $bandTag = "$MacOSVersion-dotnet$DotnetChannel-workloads$workloadBandTagVersion"
+            $bandTagRef = "$Registry/${registryName}:$bandTag"
+            if ($tags -notcontains $bandTagRef) {
+                $tags += $bandTagRef
+            }
+        }
 
         if ($BuildSha) {
             $shaTag = "$workloadTag-v$BuildSha"
@@ -571,6 +590,7 @@ try {
     if ($BaseXcodeVersion -and -not $BaseXcodeVersion.StartsWith("@")) {
         $xcodeVersionTag = $BaseXcodeVersion -replace '[^0-9.]', ''
     }
+    $resolvedWorkloadBandTag = Get-WorkloadBandTag -WorkloadVersion $resolvedWorkloadSetVersion
 
     if (($Push -or $PushOnly) -and $Registry) {
         Write-Host ""
@@ -582,6 +602,9 @@ try {
 
             if ($resolvedWorkloadSetVersion) {
                 Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion"
+                if ($resolvedWorkloadBandTag) {
+                    Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadBandTag"
+                }
                 if ($BuildSha) {
                     Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion-v$BuildSha"
                 }
@@ -589,6 +612,9 @@ try {
         } elseif ($resolvedWorkloadSetVersion) {
             # Fallback format if no Xcode version
             Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion"
+            if ($resolvedWorkloadBandTag) {
+                Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadBandTag"
+            }
             if ($BuildSha) {
                 Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion-v$BuildSha"
             }
@@ -610,11 +636,17 @@ try {
 
             if ($xcodeVersionTag -and $resolvedWorkloadSetVersion) {
                 Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion"
+                if ($resolvedWorkloadBandTag) {
+                    Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadBandTag"
+                }
                 if ($BuildSha) {
                     Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion-v$BuildSha"
                 }
             } elseif ($resolvedWorkloadSetVersion) {
                 Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion"
+                if ($resolvedWorkloadBandTag) {
+                    Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadBandTag"
+                }
                 if ($BuildSha) {
                     Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion-v$BuildSha"
                 }


### PR DESCRIPTION
## Summary
- add shared PowerShell logic to derive rolling workload band tags like `10.0.2xx`
- publish those additional aliases for `maui-linux` and `maui-macos`
- document the new floating-tag behavior in the README

## Examples
- `dotnet10.0-workloads10.0.201` also publishes `dotnet10.0-workloads10.0.2xx`
- `dotnet9.0-workloads9.0.305` also publishes `dotnet9.0-workloads9.0.3xx`
- prerelease bands also map to the corresponding `1xx/2xx/...` alias