### PR TITLE
Make .NET SDK tree user-writable in Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ FROM maui-containers/maui-linux:dotnet10.0-workloads10.0.100-rc.2.25024.3
 - `INIT_PWSH_SCRIPT` - PowerShell script to run before starting runners (Linux/Windows)
 - `INIT_BASH_SCRIPT` - Bash script to run before starting runners (Linux only)
 
+**.NET SDK location (advanced):**
+The images keep the .NET SDK at the base-image default location
+(`/usr/share/dotnet` on Linux, `C:\Program Files\dotnet` on Windows) but make
+it writable for the runtime user, so `dotnet workload update`,
+`dotnet workload install`, and `dotnet tool install -g` all succeed from CI
+without elevation. The following are set image-wide and usually don't need
+overriding:
+- `DOTNET_ROOT` / `DOTNET_INSTALL_DIR` — point at the SDK tree
+- `DOTNET_MULTILEVEL_LOOKUP=0` — stop probing for secondary installs
+- `NUGET_PACKAGES` — pinned under the runtime user's profile
+- `DOTNET_CLI_TELEMETRY_OPTOUT=1`, `DOTNET_NOLOGO=1`, `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1`
+
 See [docker/linux/README.md](docker/linux/README.md) and [docker/windows/README.md](docker/windows/README.md) for detailed documentation.
 
 ### macOS Host Provisioning

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -68,6 +68,19 @@ ENV ANDROID_HOME=/home/mauiusr/android-sdk \
     LOG_PATH=/logs \
     JAVA_HOME="/usr/lib/jvm/msopenjdk-${JDK_MAJOR_VERSION}-${TARGETARCH}"
 
+# .NET CLI environment — make the SDK tree user-writable so CI (running as
+# mauiusr) can install/update workloads and global tools without sudo. The SDK
+# itself stays at the default location from the base image; we just chown it
+# to mauiusr below. Pin NUGET_PACKAGES under $HOME so a root-owned cache can
+# never get layered in from a future base image.
+ENV DOTNET_ROOT=/usr/share/dotnet \
+    DOTNET_INSTALL_DIR=/usr/share/dotnet \
+    DOTNET_MULTILEVEL_LOOKUP=0 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
+    NUGET_PACKAGES=/home/mauiusr/.nuget/packages
+
 # Create log directory
 RUN mkdir ${LOG_PATH}
 
@@ -123,14 +136,20 @@ RUN ubuntu_release=$(lsb_release -rs) \
     && apt clean all \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the Workloads
-RUN dotnet workload install maui-android wasm-tools --version ${DOTNET_WORKLOADS_VERSION}
+# Install the Workloads as mauiusr so the non-root user can later update them
+# without sudo. This requires the SDK tree to be user-writable.
+RUN chown -R 1400:1401 /usr/share/dotnet \
+    && mkdir -p /home/mauiusr/.nuget/packages \
+    && chown -R 1400:1401 /home/mauiusr/.nuget
 
 # Fix permissions on the log directory
 RUN chown -R 1400:1401 ${LOG_PATH}
 
 # Switch to mauiusr
 USER 1400:1401
+
+# Install MAUI workloads (runs as mauiusr into the now-user-owned SDK tree)
+RUN dotnet workload install maui-android wasm-tools --version ${DOTNET_WORKLOADS_VERSION}
 
 # Install Android SDK Tool & AppleDev Tool
 RUN dotnet tool install -g AndroidSdk.Tool

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -63,6 +63,18 @@ ENV ANDROID_HOME="C:/android-sdk"
 ENV ANDROID_SDK_ROOT="C:/android-sdk"
 ENV LOG_PATH="C:\\logs\\"
 
+# .NET CLI environment — grant the Users group modify rights on the SDK tree
+# (see icacls step below) so CI can install/update workloads and global tools
+# whether the container runs as ContainerAdministrator or ContainerUser. Pin
+# NUGET_PACKAGES under the user profile to avoid a machine-wide cache getting
+# layered in from a future base image.
+ENV DOTNET_INSTALL_DIR="C:\\Program Files\\dotnet"
+ENV DOTNET_MULTILEVEL_LOOKUP="0"
+ENV DOTNET_CLI_TELEMETRY_OPTOUT="1"
+ENV DOTNET_NOLOGO="1"
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE="1"
+ENV NUGET_PACKAGES="C:\\Users\\ContainerUser\\.nuget\\packages"
+
 # Set PowerShell as the default shell
 SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -79,6 +91,12 @@ RUN choco install nodejs-lts -y
 
 # Install openjdk
 RUN choco install microsoft-openjdk$($env:JDK_MAJOR_VERSION) -y
+
+# Grant the Users group modify rights on the .NET SDK tree so non-admin
+# container users can install/update workloads and global tools without
+# elevation. This is a no-op for ContainerAdministrator but unblocks CI
+# scenarios that run as ContainerUser.
+RUN icacls 'C:\Program Files\dotnet' /grant '*S-1-5-32-545:(OI)(CI)M' /T /C | Out-Null
 
 # Install the Workloads
 RUN dotnet workload install maui wasm-tools --version $env:DOTNET_WORKLOADS_VERSION


### PR DESCRIPTION
## Why

CI that runs inside the Linux image as `mauiusr` (UID 1400) frequently fails with permission errors when it tries to run `dotnet workload update`, `dotnet workload install`, or `dotnet tool install -g`. The base `mcr.microsoft.com/dotnet/sdk` images install .NET to a root-owned location (`/usr/share/dotnet` on Linux, `C:\Program Files\dotnet` on Windows), and our Dockerfile runs the initial workload install as root before switching users — so the SDK tree stays root-owned at runtime.

## Approach

Keep the SDK base images (smallest possible diff, no duplicate install) but hand ownership of the SDK tree to the runtime user during build:

- **Linux**: `chown -R 1400:1401 /usr/share/dotnet`, then move `dotnet workload install` to run *after* the `USER 1400:1401` switch so workload manifests and packs land in the now-user-owned tree.
- **Windows**: `icacls … /grant *S-1-5-32-545:(OI)(CI)M /T` on `C:\Program Files\dotnet`. Granting modify to the built-in Users SID works whether the container ends up running as `ContainerAdministrator` or `ContainerUser`.

Also added a small set of .NET CLI env vars that any CI image should have:

- `DOTNET_ROOT` / `DOTNET_INSTALL_DIR` pinned to the SDK location
- `DOTNET_MULTILEVEL_LOOKUP=0` to guard against stray secondary installs
- `NUGET_PACKAGES` pinned under the runtime user's profile so a future base-image change can't layer in a root-owned cache
- `DOTNET_CLI_TELEMETRY_OPTOUT=1`, `DOTNET_NOLOGO=1`, `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1` for CI hygiene

macOS (Tart / `MauiProvisioning`) already installs into `~/.dotnet` and is unchanged. The emulator/test image inherits a separate runtime base and doesn't install workloads, so it's also unchanged.

## Notes for reviewers

- The Linux `chown` of `/usr/share/dotnet` is the only place that really matters for fixing the permissions bug. The env vars are defense in depth.
- On Windows the base SDK image currently runs as `ContainerAdministrator`, so no permission issue exists today — the `icacls` grant is forward-compat for CI that pins to `ContainerUser`.
- Not smoke-tested locally: the full amd64 build takes too long under emulation on arm64 macOS. PR validation (`pr-validation.yml`) will exercise it. Happy to add a `dotnet workload update` / `dotnet tool install -g` step to that workflow in a follow-up if you want explicit coverage of the permission path.