### PR TITLE
Fix linux emulator image npm install failure

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -74,7 +74,7 @@ ENV INIT_BASH_SCRIPT="/config/init.sh"
 #    fi
 
 # Set core environment variables
-ENV NODE_VERSION=22.x \
+ENV NODE_VERSION=lts.x \
     ANDROID_HOME=/home/mauiusr/android-sdk \
     ANDROID_SDK_ROOT=/home/mauiusr/android-sdk \
     DEBIAN_FRONTEND=noninteractive \
@@ -144,10 +144,13 @@ RUN ubuntu_release=$(lsb_release -rs) \
     && apt clean all \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js and npm
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash -
-RUN apt-get -qqy install nodejs
-RUN npm install -g npm
+# Install Node.js and npm from the current LTS channel.
+# Appium tracks LTS well, and avoiding npm self-upgrades prevents transient package resolution failures.
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \
+    && apt-get install -y nodejs \
+    && apt autoremove -y \
+    && apt clean all \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Appium
 RUN npm install -g appium@${APPIUM_VERSION}


### PR DESCRIPTION
## Summary
The Linux Android emulator images started failing during the Appium image build because the Dockerfile was self-upgrading npm, which now hits a `MODULE_NOT_FOUND` error in CI.

This switches the emulator image to the Node.js LTS channel and removes the npm self-upgrade step. Appium installation stays intact, but the build avoids the broken path.

## Notes
- aligns the test image's Node setup with the working Linux base image
- keeps the change scoped to `docker/test/Dockerfile`