### PR TITLE
Improve emulator image with boot readiness, runtime config, and CI smoke tests

### DIFF
--- a/.github/workflows/build-docker-windows.yml
+++ b/.github/workflows/build-docker-windows.yml
@@ -32,7 +32,7 @@ jobs:
     - name: 🛒 Checkout
       uses: actions/checkout@v4
 
-    - name: 💾 Move Docker data root to D: drive
+    - name: "💾 Move Docker data root to D: drive"
       shell: pwsh
       run: |
         Write-Host "=== Disk space before relocation ==="

--- a/.github/workflows/build-docker-windows.yml
+++ b/.github/workflows/build-docker-windows.yml
@@ -32,6 +32,35 @@ jobs:
     - name: 🛒 Checkout
       uses: actions/checkout@v4
 
+    - name: 💾 Move Docker data root to D: drive
+      shell: pwsh
+      run: |
+        Write-Host "=== Disk space before relocation ==="
+        Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{N='Free(GB)';E={[math]::Round($_.Free/1GB,1)}}, @{N='Used(GB)';E={[math]::Round($_.Used/1GB,1)}}
+
+        Write-Host "Stopping Docker service..."
+        Stop-Service docker
+
+        Write-Host "Creating D:\docker-data..."
+        New-Item -ItemType Directory -Force -Path "D:\docker-data" | Out-Null
+
+        $daemonJsonPath = "C:\ProgramData\docker\config\daemon.json"
+        if (Test-Path $daemonJsonPath) {
+          $config = Get-Content $daemonJsonPath -Raw | ConvertFrom-Json
+        } else {
+          New-Item -ItemType Directory -Force -Path (Split-Path $daemonJsonPath) | Out-Null
+          $config = [pscustomobject]@{}
+        }
+        $config | Add-Member -NotePropertyName "data-root" -NotePropertyValue "D:\docker-data" -Force
+        $config | ConvertTo-Json -Depth 5 | Set-Content $daemonJsonPath
+        Write-Host "Updated daemon.json: $(Get-Content $daemonJsonPath)"
+
+        Write-Host "Starting Docker service..."
+        Start-Service docker
+
+        Write-Host "=== Disk space after relocation ==="
+        Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{N='Free(GB)';E={[math]::Round($_.Free/1GB,1)}}, @{N='Used(GB)';E={[math]::Round($_.Used/1GB,1)}}
+
     - name: 📋 Set Variables
       id: vars
       run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -236,6 +236,36 @@ jobs:
       with:
         driver: docker
 
+    - name: 💾 Move Docker data root to D: drive (Windows)
+      if: matrix.platform == 'windows'
+      shell: pwsh
+      run: |
+        Write-Host "=== Disk space before relocation ==="
+        Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{N='Free(GB)';E={[math]::Round($_.Free/1GB,1)}}, @{N='Used(GB)';E={[math]::Round($_.Used/1GB,1)}}
+
+        Write-Host "Stopping Docker service..."
+        Stop-Service docker
+
+        Write-Host "Creating D:\docker-data..."
+        New-Item -ItemType Directory -Force -Path "D:\docker-data" | Out-Null
+
+        $daemonJsonPath = "C:\ProgramData\docker\config\daemon.json"
+        if (Test-Path $daemonJsonPath) {
+          $config = Get-Content $daemonJsonPath -Raw | ConvertFrom-Json
+        } else {
+          New-Item -ItemType Directory -Force -Path (Split-Path $daemonJsonPath) | Out-Null
+          $config = [pscustomobject]@{}
+        }
+        $config | Add-Member -NotePropertyName "data-root" -NotePropertyValue "D:\docker-data" -Force
+        $config | ConvertTo-Json -Depth 5 | Set-Content $daemonJsonPath
+        Write-Host "Updated daemon.json: $(Get-Content $daemonJsonPath)"
+
+        Write-Host "Starting Docker service..."
+        Start-Service docker
+
+        Write-Host "=== Disk space after relocation ==="
+        Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{N='Free(GB)';E={[math]::Round($_.Free/1GB,1)}}, @{N='Used(GB)';E={[math]::Round($_.Used/1GB,1)}}
+
     - name: 🔨 Build Docker image
       shell: pwsh
       run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -458,6 +458,94 @@ jobs:
           Write-Warning "⚠️ Android ${{ matrix.android_api_level }} system images not found"
         }
 
+    - name: 🚀 Runtime smoke test (boot + ADB + Appium)
+      if: matrix.build_test == 'true'
+      shell: bash
+      timeout-minutes: 15
+      run: |
+        set -euo pipefail
+
+        IMAGE="${{ env.DOCKER_REPOSITORY_TEST }}:android${{ matrix.android_api_level }}-dotnet${{ matrix.dotnet_version }}-pr-test"
+        CONTAINER_NAME="emulator-smoke-$$"
+        BOOT_TIMEOUT=360
+        APPIUM_TIMEOUT=60
+
+        cleanup() {
+          echo "🧹 Cleaning up container..."
+          docker logs "$CONTAINER_NAME" 2>&1 | tail -80 || true
+          docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+        }
+        trap cleanup EXIT
+
+        echo "🚀 Starting emulator container: $IMAGE"
+        docker run -d \
+          --name "$CONTAINER_NAME" \
+          --device /dev/kvm \
+          -e EMULATOR_BOOT_TIMEOUT=$BOOT_TIMEOUT \
+          -p 5554:5554 -p 5555:5555 -p 4723:4723 \
+          "$IMAGE"
+
+        # 1. Wait for emulator boot via Docker healthcheck or adb
+        echo "⏳ Waiting for emulator to boot (timeout: ${BOOT_TIMEOUT}s)..."
+        ELAPSED=0
+        while [ "$ELAPSED" -lt "$BOOT_TIMEOUT" ]; do
+          BOOT=$(docker exec "$CONTAINER_NAME" \
+            /home/mauiusr/.android/platform-tools/adb -s emulator-5554 shell getprop sys.boot_completed 2>/dev/null || true)
+          if [ "$(echo "$BOOT" | tr -d '[:space:]')" = "1" ]; then
+            echo "✅ Emulator booted in ~${ELAPSED}s"
+            break
+          fi
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+          if [ $((ELAPSED % 30)) -eq 0 ]; then
+            echo "  Still booting... ${ELAPSED}s"
+          fi
+        done
+
+        if [ "$ELAPSED" -ge "$BOOT_TIMEOUT" ]; then
+          echo "❌ Emulator failed to boot within ${BOOT_TIMEOUT}s"
+          exit 1
+        fi
+
+        # 2. Verify adb sees the device
+        echo "🔍 Checking adb devices..."
+        ADB_OUTPUT=$(docker exec "$CONTAINER_NAME" \
+          /home/mauiusr/.android/platform-tools/adb devices 2>/dev/null)
+        echo "$ADB_OUTPUT"
+        if echo "$ADB_OUTPUT" | grep -q "emulator-5554"; then
+          echo "✅ ADB sees emulator"
+        else
+          echo "❌ ADB does not see emulator"
+          exit 1
+        fi
+
+        # 3. Wait for Appium /status endpoint
+        echo "⏳ Waiting for Appium to respond (timeout: ${APPIUM_TIMEOUT}s)..."
+        ELAPSED=0
+        while [ "$ELAPSED" -lt "$APPIUM_TIMEOUT" ]; do
+          HTTP_CODE=$(docker exec "$CONTAINER_NAME" \
+            curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:4723/status 2>/dev/null || echo "000")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ Appium is responding on port 4723"
+            break
+          fi
+          sleep 3
+          ELAPSED=$((ELAPSED + 3))
+        done
+
+        if [ "$ELAPSED" -ge "$APPIUM_TIMEOUT" ]; then
+          echo "❌ Appium did not respond within ${APPIUM_TIMEOUT}s"
+          exit 1
+        fi
+
+        # 4. Verify healthcheck script
+        echo "🏥 Running in-container healthcheck..."
+        docker exec "$CONTAINER_NAME" /usr/bin/bash /home/mauiusr/healthcheck.sh
+        echo "✅ Healthcheck passed"
+
+        echo ""
+        echo "🎉 Runtime smoke test passed: emulator boots, ADB works, Appium responds"
+
   # Step 4: Build Tart VM Images (macOS only)
   build-tart-images:
     name: 🍎 Build Tart VM (.NET ${{ matrix.dotnet_version }})

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -236,7 +236,7 @@ jobs:
       with:
         driver: docker
 
-    - name: 💾 Move Docker data root to D: drive (Windows)
+    - name: "💾 Move Docker data root to D: drive (Windows)"
       if: matrix.platform == 'windows'
       shell: pwsh
       run: |

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ See [docker/linux/README.md](docker/linux/README.md) and [docker/windows/README.
 
 Emulator images are designed to help quickly stand up containers that are ready to use for running UI Tests with Appium on the Android Emulator. They come setup with Appium Server and the Android Emulator (for the given API level) both running and waiting when the container is started.
 
+The container uses a deterministic startup sequence: the emulator boots first and is validated via `adb`, then Appium starts only after the emulator is confirmed ready. A built-in Docker `HEALTHCHECK` reports the combined readiness of both services.
+
 **Repository:** `maui-containers/maui-emulator-linux`
 
 > NOTE: Only `linux/amd64` is available.
@@ -285,9 +287,86 @@ docker run \
 ### Volumes:
 The host folder with the built apk's can be mapped to a folder in the container.  You can then specify the location of the apk to install to appium using the container's path to it (eg: `/app/my.companyname.app-Signed.apk`).
 
-### Environment Variables:
-- `INIT_PWSH_SCRIPT` Optionally (linux or windows images) specify a path to a .ps1 script file to run before starting the runner agent (Default path is `/config/init.ps1` on linux and `C:\\config\\init.ps1` on windows - you would need to bind a volume for the script to use)
-- `INIT_BASH_SCRIPT` Optionally (linux image only) specify a path to a .ps1 script file to run before starting the runner agent (Default path is `/config/init.sh` on linux - you would need to bind a volume for the script to use)
+### Environment Variables
+
+#### Initialization hooks
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INIT_PWSH_SCRIPT` | `/config/init.ps1` | Path to a PowerShell script to run before services start. Bind a volume to supply the script. |
+| `INIT_BASH_SCRIPT` | `/config/init.sh` | Path to a bash script to run before services start. Bind a volume to supply the script. |
+| `PRE_EMULATOR_LAUNCH_SCRIPT` | _(none)_ | Path to a bash script that runs after init but before the emulator starts. Useful for patching AVD config or preloading state. |
+| `POST_BOOT_SCRIPT` | _(none)_ | Path to a bash script that runs after the emulator has booted and device tuning is applied. |
+
+#### Emulator configuration
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EMULATOR_BOOT_TIMEOUT` | `600` | Maximum seconds to wait for `sys.boot_completed`. Container exits with an error if exceeded. |
+| `EMULATOR_PORT` | `5554` | Emulator console port. ADB port is automatically `EMULATOR_PORT + 1`. |
+| `EMULATOR_WIPE_DATA` | `true` | Pass `-wipe-data` to the emulator for a clean boot each time. Set to `false` to preserve data between restarts. |
+| `EMULATOR_SNAPSHOT_MODE` | `none` | Snapshot behavior: `none` (no load/save), `load` (load existing, don't save), `save` (don't load, save on exit), `full` (load and save). |
+| `EMULATOR_EXTRA_ARGS` | _(none)_ | Additional flags appended to the emulator command line. |
+| `AVD_NAME` | `Emulator_{API_LEVEL}` | Name of the AVD to launch. Matches the AVD created at image build time by default. |
+
+#### Post-boot device tuning
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DISABLE_ANIMATIONS` | `true` | Disable window, transition, and animator animations via `adb shell settings`. Recommended for UI testing. |
+| `DISABLE_SPELLCHECKER` | `false` | Disable Android spellchecker to avoid input-field interference during tests. |
+| `ENABLE_HW_KEYBOARD` | `false` | Suppress the soft keyboard by enabling hardware keyboard mode. Useful for automation that types via `adb` input. |
+
+#### Appium configuration
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `APPIUM_LOG_LEVEL` | `debug` | Appium server log verbosity: `debug`, `info`, `warn`, `error`. |
+| `APPIUM_PORT` | `4723` | Port for the Appium HTTP server. |
+
+### Snapshot Reuse (Fast Warm Start)
+
+By default the container wipes emulator data and disables snapshots, giving a clean, deterministic boot every time. For faster iteration you can opt into snapshot reuse:
+
+**Create a snapshot (first run):**
+```bash
+docker run \
+    --device /dev/kvm \
+    -e EMULATOR_WIPE_DATA=false \
+    -e EMULATOR_SNAPSHOT_MODE=save \
+    -v emulator-avd:/home/mauiusr/.android/avd \
+    -p 4723:4723 \
+    maui-containers/maui-emulator-linux:android35-dotnet10.0
+```
+
+**Reuse the snapshot (subsequent runs):**
+```bash
+docker run \
+    --device /dev/kvm \
+    -e EMULATOR_WIPE_DATA=false \
+    -e EMULATOR_SNAPSHOT_MODE=load \
+    -v emulator-avd:/home/mauiusr/.android/avd \
+    -p 4723:4723 \
+    maui-containers/maui-emulator-linux:android35-dotnet10.0
+```
+
+> **Caution:** Snapshot reuse may leak state between test runs. Keep it opt-in and use the default `none` mode for CI pipelines that require isolation.
+
+### Healthcheck
+
+The image includes a built-in Docker `HEALTHCHECK` that validates:
+1. The emulator has fully booted (`sys.boot_completed == 1`)
+2. The Appium server is responding on its configured port
+
+Use `docker inspect --format='{{.State.Health.Status}}'` or wait for `healthy` status in orchestrators like Docker Compose.
+
+### Helper script
+
+Use `docker/test/run.ps1` for a quick local launch:
+
+```powershell
+# Default: API 35, .NET 10.0
+pwsh ./docker/test/run.ps1 -AndroidSdkApiLevel 35 -DotnetVersion 10.0
+
+# With runtime options
+pwsh ./docker/test/run.ps1 -AndroidSdkApiLevel 35 -DisableSpellchecker -EnableHwKeyboard
+```
 
 ### Variants
 

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -65,6 +65,21 @@ LABEL org.opencontainers.image.title="MAUI Android Emulator Test Container" \
 ENV INIT_PWSH_SCRIPT="/config/init.ps1"
 ENV INIT_BASH_SCRIPT="/config/init.sh"
 
+# Runtime-configurable emulator and service options (override with -e at docker run)
+ENV EMULATOR_BOOT_TIMEOUT=600
+ENV EMULATOR_PORT=5554
+ENV EMULATOR_WIPE_DATA=true
+ENV EMULATOR_SNAPSHOT_MODE=none
+ENV EMULATOR_EXTRA_ARGS=""
+ENV AVD_NAME=""
+ENV DISABLE_ANIMATIONS=true
+ENV DISABLE_SPELLCHECKER=false
+ENV ENABLE_HW_KEYBOARD=false
+ENV POST_BOOT_SCRIPT=""
+ENV PRE_EMULATOR_LAUNCH_SCRIPT=""
+ENV APPIUM_LOG_LEVEL=debug
+ENV APPIUM_PORT=4723
+
 # Not needed currently as linux android sdk doesn't support arm64 emulators
 # Generate environment variables
 #RUN if [ "$TARGETARCH" = "arm64" ]; then \
@@ -171,6 +186,7 @@ COPY scripts/emulator.sh /home/mauiusr/emulator.sh
 COPY scripts/appium.sh /home/mauiusr/appium.sh
 COPY scripts/androidportforward.sh /home/mauiusr/androidportforward.sh
 COPY scripts/init.sh /home/mauiusr/init.sh
+COPY scripts/healthcheck.sh /home/mauiusr/healthcheck.sh
 
 # Install appium UIautomator2 driver
 RUN appium driver install uiautomator2@${APPIUM_UIAUTOMATOR2_DRIVER_VERSION}
@@ -201,6 +217,10 @@ RUN android avd create \
 
 # Expose ports for Appium, Android emulator, ADB, and GRPC
 EXPOSE 4723 5554 5555 8554
+
+# Healthcheck: verifies emulator is booted and Appium is listening
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=3 \
+    CMD /usr/bin/bash /home/mauiusr/healthcheck.sh
 
 # Default command
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/test/run.ps1
+++ b/docker/test/run.ps1
@@ -1,11 +1,23 @@
-Param([String]$AndroidSdkApiLevel=35,
-    [String]$AdbKeyFolder="$env:USERPROFILE/.android",
-    [Int]$AdbPortMapping=5555,
-    [Int]$EmulatorPortMapping=5554,
-    [Int]$GrpcPortMapping=8554,
-    [Int]$AppiumPortMapping=4723,
-    [bool]$BindAdbKeys=$true)
-
+Param(
+    [String]$AndroidSdkApiLevel = 35,
+    [String]$DotnetVersion = "9.0",
+    [String]$DockerRepository = "maui-containers/maui-emulator-linux",
+    [String]$AdbKeyFolder = "$env:USERPROFILE/.android",
+    [Int]$AdbPortMapping = 5555,
+    [Int]$EmulatorPortMapping = 5554,
+    [Int]$GrpcPortMapping = 8554,
+    [Int]$AppiumPortMapping = 4723,
+    [switch]$BindAdbKeys,
+    # Runtime configuration environment variables
+    [Int]$EmulatorBootTimeout = 0,
+    [String]$EmulatorSnapshotMode = "",
+    [switch]$NoWipeData,
+    [switch]$DisableAnimations,
+    [switch]$DisableSpellchecker,
+    [switch]$EnableHwKeyboard,
+    [String]$EmulatorExtraArgs = "",
+    [String]$AvdName = ""
+)
 
 $runArgs = @(
     "run", "-d",
@@ -16,12 +28,39 @@ $runArgs = @(
     "-p", "${AppiumPortMapping}:4723/tcp"
 )
 
-if ($bindAdbKeys) {
+if ($BindAdbKeys) {
     $runArgs += "--mount", "type=bind,src=${AdbKeyFolder}/adbkey,dst=/home/mauiusr/.android/adbkey,readonly"
     $runArgs += "--mount", "type=bind,src=${AdbKeyFolder}/adbkey.pub,dst=/home/mauiusr/.android/adbkey.pub,readonly"
 }
 
+# Pass runtime config as environment variables (only when explicitly set)
+if ($EmulatorBootTimeout -gt 0) {
+    $runArgs += "-e", "EMULATOR_BOOT_TIMEOUT=$EmulatorBootTimeout"
+}
+if ($EmulatorSnapshotMode -ne "") {
+    $runArgs += "-e", "EMULATOR_SNAPSHOT_MODE=$EmulatorSnapshotMode"
+}
+if ($NoWipeData) {
+    $runArgs += "-e", "EMULATOR_WIPE_DATA=false"
+}
+if ($DisableAnimations) {
+    $runArgs += "-e", "DISABLE_ANIMATIONS=true"
+}
+if ($DisableSpellchecker) {
+    $runArgs += "-e", "DISABLE_SPELLCHECKER=true"
+}
+if ($EnableHwKeyboard) {
+    $runArgs += "-e", "ENABLE_HW_KEYBOARD=true"
+}
+if ($EmulatorExtraArgs -ne "") {
+    $runArgs += "-e", "EMULATOR_EXTRA_ARGS=$EmulatorExtraArgs"
+}
+if ($AvdName -ne "") {
+    $runArgs += "-e", "AVD_NAME=$AvdName"
+}
 
-$runArgs += "maui-containers/maui-emulator-linux:android$AndroidSdkApiLevel-dotnet9.0"
+$imageTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}"
+$runArgs += $imageTag
 
+Write-Host "Starting emulator container: docker $($runArgs -join ' ')"
 & docker $runArgs

--- a/docker/test/scripts/androidportforward.sh
+++ b/docker/test/scripts/androidportforward.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/bash
 
+EMULATOR_PORT=${EMULATOR_PORT:-5554}
+ADB_PORT=$((EMULATOR_PORT + 1))
+
 # Get the local IP address
 local_ip=$(hostname -I | awk '{print $1}')
 
 # Forward the ports for adb/emulator so we can connect from the host
-/usr/bin/socat tcp-listen:5554,bind=${local_ip},fork tcp:127.0.0.1:5554 &
-/usr/bin/socat tcp-listen:5555,bind=${local_ip},fork tcp:127.0.0.1:5555
+/usr/bin/socat tcp-listen:${EMULATOR_PORT},bind=${local_ip},fork tcp:127.0.0.1:${EMULATOR_PORT} &
+/usr/bin/socat tcp-listen:${ADB_PORT},bind=${local_ip},fork tcp:127.0.0.1:${ADB_PORT}

--- a/docker/test/scripts/appium.sh
+++ b/docker/test/scripts/appium.sh
@@ -1,8 +1,33 @@
 #!/usr/bin/bash
+set -euo pipefail
 
-appium \
+READY_FILE="/tmp/.emulator-ready"
+APPIUM_LOG_LEVEL=${APPIUM_LOG_LEVEL:-debug}
+APPIUM_PORT=${APPIUM_PORT:-4723}
+
+echo "Waiting for emulator readiness before starting Appium..."
+
+# Wait for the emulator ready signal with a reasonable timeout
+WAIT=0
+TIMEOUT=660
+while [ ! -f "$READY_FILE" ] && [ "$WAIT" -lt "$TIMEOUT" ]; do
+    sleep 2
+    WAIT=$((WAIT + 2))
+    if [ $((WAIT % 30)) -eq 0 ]; then
+        echo "  Appium waiting for emulator... ${WAIT}s elapsed"
+    fi
+done
+
+if [ ! -f "$READY_FILE" ]; then
+    echo "ERROR: Emulator never became ready after ${TIMEOUT}s — not starting Appium"
+    exit 1
+fi
+
+echo "Emulator is ready — starting Appium on port $APPIUM_PORT"
+
+exec appium \
   --session-override \
-  --log-level debug \
+  --log-level "$APPIUM_LOG_LEVEL" \
   --log-timestamp \
-  --port 4723 \
+  --port "$APPIUM_PORT" \
   --allow-insecure *:chromedriver_autodownload

--- a/docker/test/scripts/emulator.sh
+++ b/docker/test/scripts/emulator.sh
@@ -1,14 +1,136 @@
 #!/usr/bin/bash
+set -euo pipefail
 
 export ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH=/logs/androidsdktool.log
+
+ADB="/home/mauiusr/.android/platform-tools/adb"
+EMULATOR="/home/mauiusr/.android/emulator/emulator"
+
+# Configurable via environment variables
+EMULATOR_BOOT_TIMEOUT=${EMULATOR_BOOT_TIMEOUT:-600}
+EMULATOR_PORT=${EMULATOR_PORT:-5554}
+EMULATOR_WIPE_DATA=${EMULATOR_WIPE_DATA:-true}
+EMULATOR_SNAPSHOT_MODE=${EMULATOR_SNAPSHOT_MODE:-none}
+EMULATOR_EXTRA_ARGS=${EMULATOR_EXTRA_ARGS:-}
+AVD_NAME=${AVD_NAME:-Emulator_${ANDROID_SDK_API_LEVEL}}
+DISABLE_ANIMATIONS=${DISABLE_ANIMATIONS:-true}
+DISABLE_SPELLCHECKER=${DISABLE_SPELLCHECKER:-false}
+ENABLE_HW_KEYBOARD=${ENABLE_HW_KEYBOARD:-false}
+
+# Readiness marker used by downstream services (Appium, healthcheck)
+READY_FILE="/tmp/.emulator-ready"
+rm -f "$READY_FILE"
+
+echo "=== Emulator configuration ==="
+echo "  AVD:                $AVD_NAME"
+echo "  Port:               $EMULATOR_PORT"
+echo "  Boot timeout:       ${EMULATOR_BOOT_TIMEOUT}s"
+echo "  Wipe data:          $EMULATOR_WIPE_DATA"
+echo "  Snapshot mode:      $EMULATOR_SNAPSHOT_MODE"
+echo "  Disable animations: $DISABLE_ANIMATIONS"
+echo "  Disable spellcheck: $DISABLE_SPELLCHECKER"
+echo "  HW keyboard:        $ENABLE_HW_KEYBOARD"
+echo "  Extra args:         $EMULATOR_EXTRA_ARGS"
 
 # Permissions for KVM
 sudo chown 1400:1401 /dev/kvm
 
-# Seems that stopping/starting adb causes adb key to generate
-/home/mauiusr/.android/platform-tools/adb kill-server
-/home/mauiusr/.android/platform-tools/adb start-server
+# Restart adb to generate keys
+$ADB kill-server
+$ADB start-server
 
-# Start our emulator
-#android avd start --home="${ANDROID_HOME}" --name=Emulator_${ANDROID_SDK_API_LEVEL} --wait-boot --wait-exit --gpu="swiftshader_indirect" --accel="on" --wipe-data --no-window --no-audio --no-boot-anim --grpc=8554
-/home/mauiusr/.android/emulator/emulator -avd Emulator_${ANDROID_SDK_API_LEVEL} -no-snapshot-load -grpc 8554 -wipe-data -gpu swiftshader_indirect -accel on -no-window -no-audio -no-boot-anim
+# Build emulator launch arguments
+LAUNCH_ARGS="-avd $AVD_NAME -port $EMULATOR_PORT -grpc 8554 -gpu swiftshader_indirect -accel on -no-window -no-audio -no-boot-anim"
+
+if [ "$EMULATOR_WIPE_DATA" = "true" ]; then
+    LAUNCH_ARGS="$LAUNCH_ARGS -wipe-data"
+fi
+
+# Snapshot mode: none = disable load/save, load = load snapshot, save = save on exit, full = load+save
+case "$EMULATOR_SNAPSHOT_MODE" in
+    none)
+        LAUNCH_ARGS="$LAUNCH_ARGS -no-snapshot-load -no-snapshot-save"
+        ;;
+    load)
+        LAUNCH_ARGS="$LAUNCH_ARGS -no-snapshot-save"
+        ;;
+    save)
+        LAUNCH_ARGS="$LAUNCH_ARGS -no-snapshot-load"
+        ;;
+    full)
+        # Default snapshot behavior — load and save
+        ;;
+    *)
+        echo "WARNING: Unknown EMULATOR_SNAPSHOT_MODE '$EMULATOR_SNAPSHOT_MODE', defaulting to none"
+        LAUNCH_ARGS="$LAUNCH_ARGS -no-snapshot-load -no-snapshot-save"
+        ;;
+esac
+
+if [ -n "$EMULATOR_EXTRA_ARGS" ]; then
+    LAUNCH_ARGS="$LAUNCH_ARGS $EMULATOR_EXTRA_ARGS"
+fi
+
+echo "Starting emulator: $EMULATOR $LAUNCH_ARGS"
+$EMULATOR $LAUNCH_ARGS &
+EMULATOR_PID=$!
+
+# Wait for emulator to boot by polling sys.boot_completed
+echo "Waiting for emulator to boot (timeout: ${EMULATOR_BOOT_TIMEOUT}s)..."
+BOOT_WAIT=0
+RETRY_INTERVAL=2
+BOOTED=false
+
+while [ "$BOOT_WAIT" -lt "$EMULATOR_BOOT_TIMEOUT" ]; do
+    RESULT=$($ADB -s emulator-${EMULATOR_PORT} shell getprop sys.boot_completed 2>/dev/null || true)
+    if [ "$(echo "$RESULT" | tr -d '[:space:]')" = "1" ]; then
+        BOOTED=true
+        break
+    fi
+    sleep $RETRY_INTERVAL
+    BOOT_WAIT=$((BOOT_WAIT + RETRY_INTERVAL))
+    if [ $((BOOT_WAIT % 30)) -eq 0 ]; then
+        echo "  Still waiting... ${BOOT_WAIT}s elapsed"
+    fi
+done
+
+if [ "$BOOTED" != "true" ]; then
+    echo "ERROR: Emulator failed to boot within ${EMULATOR_BOOT_TIMEOUT}s"
+    exit 1
+fi
+
+echo "Emulator booted successfully in ~${BOOT_WAIT}s"
+
+# Unlock screen
+$ADB -s emulator-${EMULATOR_PORT} shell input keyevent 82 || true
+
+# Post-boot device tuning (inspired by ReactiveCircus/android-emulator-runner)
+if [ "$DISABLE_ANIMATIONS" = "true" ]; then
+    echo "Disabling animations..."
+    $ADB -s emulator-${EMULATOR_PORT} shell settings put global window_animation_scale 0.0 || true
+    $ADB -s emulator-${EMULATOR_PORT} shell settings put global transition_animation_scale 0.0 || true
+    $ADB -s emulator-${EMULATOR_PORT} shell settings put global animator_duration_scale 0.0 || true
+fi
+
+if [ "$DISABLE_SPELLCHECKER" = "true" ]; then
+    echo "Disabling spellchecker..."
+    $ADB -s emulator-${EMULATOR_PORT} shell settings put secure spell_checker_enabled 0 || true
+fi
+
+if [ "$ENABLE_HW_KEYBOARD" = "true" ]; then
+    echo "Suppressing IME with hardware keyboard..."
+    $ADB -s emulator-${EMULATOR_PORT} shell settings put secure show_ime_with_hard_keyboard 0 || true
+fi
+
+# Execute optional post-boot hook
+POST_BOOT_SCRIPT=${POST_BOOT_SCRIPT:-}
+if [ -n "$POST_BOOT_SCRIPT" ] && [ -f "$POST_BOOT_SCRIPT" ]; then
+    echo "Running post-boot script: $POST_BOOT_SCRIPT"
+    /usr/bin/bash "$POST_BOOT_SCRIPT"
+fi
+
+# Signal readiness
+touch "$READY_FILE"
+echo "Emulator is ready — signalled downstream services"
+
+# Keep foreground so supervisord can manage the process
+wait $EMULATOR_PID

--- a/docker/test/scripts/healthcheck.sh
+++ b/docker/test/scripts/healthcheck.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+# Lightweight healthcheck: emulator booted + Appium listening.
+# Used by HEALTHCHECK in Dockerfile and external orchestrators.
+
+ADB="/home/mauiusr/.android/platform-tools/adb"
+EMULATOR_PORT=${EMULATOR_PORT:-5554}
+APPIUM_PORT=${APPIUM_PORT:-4723}
+
+# 1. Emulator must report boot completed
+BOOT=$($ADB -s emulator-${EMULATOR_PORT} shell getprop sys.boot_completed 2>/dev/null || true)
+if [ "$(echo "$BOOT" | tr -d '[:space:]')" != "1" ]; then
+    exit 1
+fi
+
+# 2. Appium /status must respond
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${APPIUM_PORT}/status" 2>/dev/null || echo "000")
+if [ "$HTTP_CODE" != "200" ]; then
+    exit 1
+fi
+
+exit 0

--- a/docker/test/scripts/init.sh
+++ b/docker/test/scripts/init.sh
@@ -2,6 +2,7 @@
 
 INIT_PWSH_SCRIPT=${INIT_PWSH_SCRIPT:-""}
 INIT_BASH_SCRIPT=${INIT_BASH_SCRIPT:-""}
+PRE_EMULATOR_LAUNCH_SCRIPT=${PRE_EMULATOR_LAUNCH_SCRIPT:-""}
 
 echo "init.sh checking for scripts..."
 
@@ -16,6 +17,13 @@ if [ -f "$INIT_PWSH_SCRIPT" ]; then
   echo "Found initialization script at $INIT_PWSH_SCRIPT, executing..."
   /usr/bin/pwsh "$INIT_PWSH_SCRIPT"
   echo "Initialization script executed successfully."
+fi
+
+# Run pre-emulator-launch script (runs after init but before the emulator starts)
+if [ -n "$PRE_EMULATOR_LAUNCH_SCRIPT" ] && [ -f "$PRE_EMULATOR_LAUNCH_SCRIPT" ]; then
+  echo "Found pre-emulator-launch script at $PRE_EMULATOR_LAUNCH_SCRIPT, executing..."
+  /usr/bin/bash "$PRE_EMULATOR_LAUNCH_SCRIPT"
+  echo "Pre-emulator-launch script executed successfully."
 fi
 
 echo "init.sh script executed successfully."

--- a/docker/test/scripts/supervisord.conf
+++ b/docker/test/scripts/supervisord.conf
@@ -27,17 +27,17 @@ stdout_logfile=%(ENV_LOG_PATH)s/emulator.stdout.log
 redirect_stderr=true
 priority=2
 stopsignal=TERM
-stopwaitsecs=10
+stopwaitsecs=30
 
 [program:appium]
 directory=/home/mauiusr
 command=/usr/bin/bash /home/mauiusr/appium.sh
 autostart=true
-autorestart=false
-startretries=0
+autorestart=true
+startretries=3
 stdout_logfile=%(ENV_LOG_PATH)s/appium.stdout.log
 redirect_stderr=true
-priority=2
+priority=3
 
 [program:androidportforward]
 directory=/home/mauiusr
@@ -46,4 +46,4 @@ autostart=true
 autorestart=true
 stdout_logfile=%(ENV_LOG_PATH)s/androidportforward.stdout.log
 redirect_stderr=true
-priority=3
+priority=4


### PR DESCRIPTION
Our emulator container previously started the emulator and Appium in parallel with no coordination -- Appium could start before the emulator was ready, and there was no way to know from outside the container when services were actually usable. After auditing [ReactiveCircus/android-emulator-runner](https://github.com/ReactiveCircus/android-emulator-runner), this PR brings over the best patterns (boot polling, post-boot device tuning, runtime configurability) while preserving our image-first Docker model.

## What changed

- **Deterministic startup sequence:** `emulator.sh` now polls `adb shell getprop sys.boot_completed` with a configurable timeout, then signals readiness via a marker file. Appium waits for that signal before starting -- no more race condition.
- **Post-boot device tuning:** Disables animations (window, transition, animator scales), with opt-in spellchecker suppression and hardware keyboard mode, matching upstream best practices for UI test stability.
- **Docker HEALTHCHECK:** New `healthcheck.sh` validates both emulator boot and Appium `/status`, so orchestrators and `docker inspect` can observe true readiness.
- **14 new runtime env vars:** Boot timeout, snapshot mode, wipe-data toggle, extra emulator args, AVD name, Appium log level/port, pre/post-boot hooks -- all configurable at `docker run` without rebuilding.
- **Snapshot reuse support:** Four modes (`none`, `load`, `save`, `full`) with documented volume mount patterns for fast warm starts.
- **`run.ps1` fixes:** Parameterized `DotnetVersion` and `DockerRepository` (was hardcoded to `dotnet9.0`), passes through new env vars.
- **CI smoke test:** `pr-validation.yml` now boots the emulator container, verifies `adb devices`, checks Appium `/status`, and runs the healthcheck -- real runtime validation instead of just checking binaries exist.
- **README overhaul:** Full env var reference tables, snapshot reuse guide, healthcheck docs, and helper script examples for the emulator section.

## Defaults preserved

All defaults match previous behavior (wipe data, no snapshots, animations disabled). New features are strictly opt-in -- existing users see no behavior change.

## Areas for careful review

- The supervisord priority ordering change (emulator at 2, appium at 3, portforward at 4) and appium's `autorestart=true` setting ensure Appium retries if the readiness wait times out. Worth verifying this matches desired behavior.
- The CI smoke test requires `/dev/kvm` on the GitHub runner. GitHub-hosted `ubuntu-latest` runners provide this, but if the org uses custom runners they may not.