### PR TITLE
Update MAUI workload installs

### DIFF
--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -99,7 +99,7 @@ RUN choco install microsoft-openjdk$($env:JDK_MAJOR_VERSION) -y
 RUN icacls 'C:\Program Files\dotnet' /grant '*S-1-5-32-545:(OI)(CI)M' /T /C | Out-Null
 
 # Install the Workloads
-RUN dotnet workload install maui wasm-tools --version $env:DOTNET_WORKLOADS_VERSION
+RUN dotnet workload install maui android ios maccatalyst macos wasm-tools tvos --version $env:DOTNET_WORKLOADS_VERSION
 
 # Install Android SDK Tool & AppleDev Tool
 RUN dotnet tool install -g AndroidSdk.Tool

--- a/provisioning/MauiProvisioning/Public/Invoke-MauiProvisioning.ps1
+++ b/provisioning/MauiProvisioning/Public/Invoke-MauiProvisioning.ps1
@@ -296,7 +296,10 @@ function Invoke-MauiProvisioning {
     }
 
     $installedWorkloads = Get-InstalledDotnetWorkloads -DotnetPath $dotnetForChecks
-    $requiredWorkloads = @("maui", "wasm-tools")
+    $requiredWorkloads = @("maui")
+    if (-not $SkipAndroid) {
+        $requiredWorkloads += @("android")
+    }
     if (-not $SkipIOS -and $iOSDetails) {
         $requiredWorkloads += @("ios", "maccatalyst")
     }
@@ -306,6 +309,7 @@ function Invoke-MauiProvisioning {
     if (-not $SkipTvOS -and $tvOsDetails) {
         $requiredWorkloads += @("tvos")
     }
+    $requiredWorkloads += @("wasm-tools")
     $workloadsToInstall = @()
 
     foreach ($workloadId in $requiredWorkloads) {


### PR DESCRIPTION
Windows images were only installing the MAUI meta-workload and wasm-tools, and the Tart macOS provisioning did not explicitly request the Android workload. This aligns the Windows and macOS MAUI environments with the full cross-target workload set while leaving Linux unchanged.

## Summary

- Expands the Windows Docker workload install to include `maui`, `android`, `ios`, `maccatalyst`, `macos`, `wasm-tools`, and `tvos`.
- Makes Tart macOS provisioning explicitly include `android` alongside `maui`, `ios`, `maccatalyst`, `macos`, `tvos`, and `wasm-tools`.
- Preserves the existing macOS provisioning skip flags and leaves the Linux Docker workload list unchanged.

## Touched image families

- Windows Docker MAUI image
- Tart macOS MAUI VM provisioning

## Required environment variables

N/A

## Validation

- Parsed affected PowerShell scripts with the PowerShell parser.
- Ran `git diff --check`.