### PR TITLE
Bump base Xcode to 26.4.1 in Tart platform matrix

### DIFF
--- a/tart/macos/config/platform-matrix.json
+++ b/tart/macos/config/platform-matrix.json
@@ -3,7 +3,7 @@
         "tahoe": {
             "FullName": "macOS Tahoe 16",
             "MinXcodeVersion": "26.2",
-            "RecommendedXcodeVersion": "26.2"
+            "RecommendedXcodeVersion": "26.4.1"
         }
     },
     "DotnetChannels": {
@@ -11,7 +11,7 @@
             "Channel": "9.0",
             "LTS": false,
             "MacOSVersion": "tahoe",
-            "BaseXcodeVersion": "26.2",
+            "BaseXcodeVersion": "26.4.1",
             "AdditionalXcodeVersions": [],
             "MinMacOSVersion": "tahoe",
             "SupportedWorkloads": [
@@ -27,7 +27,7 @@
             "Channel": "10.0",
             "LTS": false,
             "MacOSVersion": "tahoe",
-            "BaseXcodeVersion": "26.2",
+            "BaseXcodeVersion": "26.4.1",
             "AdditionalXcodeVersions": [],
             "MinMacOSVersion": "tahoe",
             "SupportedWorkloads": [


### PR DESCRIPTION
Picks up the latest stable cirruslabs Tahoe base image so the macOS VM builds use Xcode 26.4.1 instead of 26.2. Verified `ghcr.io/cirruslabs/macos-tahoe-xcode:26.4.1` is published.

Three field updates in `tart/macos/config/platform-matrix.json`:
- `MacOSVersions.tahoe.RecommendedXcodeVersion`: `26.2` -> `26.4.1`
- `DotnetChannels."9.0".BaseXcodeVersion`: `26.2` -> `26.4.1`
- `DotnetChannels."10.0".BaseXcodeVersion`: `26.2` -> `26.4.1`

`MinXcodeVersion` is intentionally left at `26.2` as the compatibility floor.