### PR TITLE
Increase Tart VM disk size

### DIFF
--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -187,7 +187,7 @@ pwsh ./macos/tart/scripts/build.ps1 \
   -DotnetChannel 10.0 \
   -CPUCount 8 \
   -MemoryGB 16 \
-  -DiskSizeGB 100
+  -DiskSizeGB 160
 ```
 
 ### Running VMs

--- a/tart/macos/config/variables.json
+++ b/tart/macos/config/variables.json
@@ -5,8 +5,8 @@
   "ssh_password": "admin",
   "registry": "",
   "build_settings": {
-    "maui_image_disk_size_gb": 60,
-    "ci_image_disk_size_gb": 50
+    "maui_image_disk_size_gb": 160,
+    "ci_image_disk_size_gb": 160
   },
   "optimization": {
     "disable_spotlight": true,

--- a/tart/macos/scripts/build.ps1
+++ b/tart/macos/scripts/build.ps1
@@ -21,6 +21,8 @@ Param(
     [string]$BuildSha = "",
     [int]$CPUCount = 4,
     [int]$MemoryGB = 8,
+    [ValidateRange(0, 4096)]
+    [int]$DiskSizeGB = 0,
     [switch]$Push,
     [switch]$PushOnly,
     [switch]$DryRun,
@@ -131,6 +133,25 @@ function Test-VersionCompatibility {
 
     return $true
 }
+
+function Get-OptionalPropertyValue {
+    param(
+        [object]$InputObject,
+        [string]$Name
+    )
+
+    if (-not $InputObject) {
+        return $null
+    }
+
+    $property = $InputObject.PSObject.Properties | Where-Object { $_.Name -eq $Name } | Select-Object -First 1
+    if ($property) {
+        return $property.Value
+    }
+
+    return $null
+}
+
 # Normalize inputs
 if ($DotnetChannel) {
     $DotnetChannel = $DotnetChannel.Trim()
@@ -232,6 +253,21 @@ if (-not $ImageName) {
     }
 }
 
+if ($DiskSizeGB -eq 0) {
+    $buildSettings = Get-OptionalPropertyValue -InputObject $config -Name "build_settings"
+    $diskSizePropertyName = switch ($ImageType) {
+        "maui" { "maui_image_disk_size_gb" }
+        "ci" { "ci_image_disk_size_gb" }
+    }
+    $configuredDiskSizeGB = Get-OptionalPropertyValue -InputObject $buildSettings -Name $diskSizePropertyName
+
+    if ($configuredDiskSizeGB) {
+        $DiskSizeGB = [int]$configuredDiskSizeGB
+    } else {
+        $DiskSizeGB = 160
+    }
+}
+
 # Set base image for layered builds (not needed for push-only mode)
 if (-not $PushOnly -and -not $BaseImage) {
     $BaseImage = switch ($ImageType) {
@@ -271,6 +307,7 @@ if (-not $PushOnly) {
     Write-Host "Base Image: $BaseImage"
     Write-Host "CPU Count: $CPUCount"
     Write-Host "Memory: ${MemoryGB}GB"
+    Write-Host "Disk: ${DiskSizeGB}GB"
 }
 if ($Registry) {
     Write-Host "Registry: $Registry"
@@ -548,6 +585,7 @@ try {
             "additional_xcode_versions" = ($AdditionalXcodeVersions -join ",")
             "cpu_count" = $CPUCount
             "memory_gb" = $MemoryGB
+            "disk_size_gb" = $DiskSizeGB
         }
 
         # Add any additional variables from config file

--- a/tart/macos/templates/maui.pkr.hcl
+++ b/tart/macos/templates/maui.pkr.hcl
@@ -61,6 +61,12 @@ variable "memory_gb" {
   default     = 8
 }
 
+variable "disk_size_gb" {
+  type        = number
+  description = "Disk size in GB for the VM"
+  default     = 160
+}
+
 variable "ssh_username" {
   type        = string
   description = "SSH username"
@@ -108,7 +114,7 @@ source "tart-cli" "maui" {
   vm_name      = var.image_name
   cpu_count    = var.cpu_count
   memory_gb    = var.memory_gb
-  disk_size_gb = 120
+  disk_size_gb = var.disk_size_gb
   ssh_password = var.ssh_password
   ssh_timeout  = "120s"
   ssh_username = var.ssh_username


### PR DESCRIPTION
The current Cirrus Labs macOS Tahoe Xcode 26.4.1 base image is now 140 GB, but our Tart Packer template still requested a 120 GB disk. Tart refuses to resize a VM to a smaller disk, so PR validation failed before provisioning could start.

This makes the Tart VM disk size configurable, raises the default MAUI/CI disk size to 160 GB, and wires the existing build settings through to Packer via `disk_size_gb`. The build script now also supports the documented `-DiskSizeGB` override for local builds.

Validation:
- Ran `build.ps1` in dry-run mode for the failing .NET 9.0 / Xcode 26.4.1 path and confirmed Packer receives `disk_size_gb=160`.