### PR TITLE
Use explicit .NET preview image tags

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -267,6 +267,7 @@ jobs:
         Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{N='Free(GB)';E={[math]::Round($_.Free/1GB,1)}}, @{N='Used(GB)';E={[math]::Round($_.Used/1GB,1)}}
 
     - name: 🔨 Build Docker image
+      id: build_base_image
       shell: pwsh
       run: |
         Write-Host "Building Docker image for .NET ${{ matrix.dotnet_version }} on ${{ matrix.platform }}"
@@ -281,10 +282,25 @@ jobs:
         }
         ./docker/build.ps1 @buildArgs
 
+    - name: 🏷️ Resolve base image tag
+      id: base_image
+      shell: pwsh
+      run: |
+        $imageTags = "${{ steps.build_base_image.outputs.image_tags }}" -split '\|' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        $imageName = $imageTags | Where-Object { $_ -like "${{ env.DOCKER_REPOSITORY_BASE }}:*-pr-test" } | Select-Object -First 1
+
+        if (-not $imageName) {
+          Write-Error "Could not resolve PR validation image tag from build outputs: $($imageTags -join ', ')"
+          exit 1
+        }
+
+        Write-Host "Resolved validation image: $imageName"
+        "image_name=$imageName" >> $env:GITHUB_OUTPUT
+
     - name: 🔍 Validate Docker image
       shell: pwsh
       run: |
-        $imageName = "${{ env.DOCKER_REPOSITORY_BASE }}:dotnet${{ matrix.dotnet_version }}-pr-test"
+        $imageName = "${{ steps.base_image.outputs.image_name }}"
         Write-Host "Validating image: $imageName"
         $imageExists = docker images --format "{{.Repository}}:{{.Tag}}" | Select-String -Pattern "$imageName"
         if ($imageExists) {
@@ -301,7 +317,7 @@ jobs:
       shell: pwsh
       run: |
         # Construct image name
-        $imageName = "${{ env.DOCKER_REPOSITORY_BASE }}:dotnet${{ matrix.dotnet_version }}-pr-test"
+        $imageName = "${{ steps.base_image.outputs.image_name }}"
 
         Write-Host "Testing basic functionality of: $imageName"
         
@@ -377,7 +393,7 @@ jobs:
       shell: pwsh
       run: |
         # Construct image name
-        $imageName = "${{ env.DOCKER_REPOSITORY_BASE }}:dotnet${{ matrix.dotnet_version }}-pr-test"
+        $imageName = "${{ steps.base_image.outputs.image_name }}"
 
         Write-Host "Verifying runner functionality is absent: $imageName"
 
@@ -422,6 +438,7 @@ jobs:
 
     - name: 🔨 Build test image
       if: matrix.build_test == 'true'
+      id: build_test_image
       shell: pwsh
       run: |
         Write-Host "Building test image for .NET ${{ matrix.dotnet_version }} on ${{ matrix.platform }}"
@@ -440,11 +457,27 @@ jobs:
         }
         ./docker/test/build.ps1 @buildArgs
 
+    - name: 🏷️ Resolve test image tag
+      if: matrix.build_test == 'true'
+      id: test_image
+      shell: pwsh
+      run: |
+        $imageTags = "${{ steps.build_test_image.outputs.image_tags }}" -split '\|' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        $imageName = $imageTags | Where-Object { $_ -like "${{ env.DOCKER_REPOSITORY_TEST }}:*-pr-test" } | Select-Object -First 1
+
+        if (-not $imageName) {
+          Write-Error "Could not resolve PR validation test image tag from build outputs: $($imageTags -join ', ')"
+          exit 1
+        }
+
+        Write-Host "Resolved validation test image: $imageName"
+        "image_name=$imageName" >> $env:GITHUB_OUTPUT
+
     - name: 🔍 Validate test image
       if: matrix.build_test == 'true'
       shell: pwsh
       run: |
-        $imageName = "${{ env.DOCKER_REPOSITORY_TEST }}:android${{ matrix.android_api_level }}-dotnet${{ matrix.dotnet_version }}-pr-test"
+        $imageName = "${{ steps.test_image.outputs.image_name }}"
         Write-Host "Validating image: $imageName"
         $imageExists = docker images --format "{{.Repository}}:{{.Tag}}" | Select-String -Pattern "$imageName"
         if ($imageExists) {
@@ -460,7 +493,7 @@ jobs:
       shell: pwsh
       run: |
         # Construct image name
-        $imageName = "${{ env.DOCKER_REPOSITORY_TEST }}:android${{ matrix.android_api_level }}-dotnet${{ matrix.dotnet_version }}-pr-test"
+        $imageName = "${{ steps.test_image.outputs.image_name }}"
 
         Write-Host "Testing Appium/Emulator functionality of: $imageName"
         
@@ -495,7 +528,7 @@ jobs:
       run: |
         set -euo pipefail
 
-        IMAGE="${{ env.DOCKER_REPOSITORY_TEST }}:android${{ matrix.android_api_level }}-dotnet${{ matrix.dotnet_version }}-pr-test"
+        IMAGE="${{ steps.test_image.outputs.image_name }}"
         CONTAINER_NAME="emulator-smoke-$$"
         BOOT_TIMEOUT=360
         APPIUM_TIMEOUT=60

--- a/README.md
+++ b/README.md
@@ -57,14 +57,16 @@ Images are published under the `maui-containers` organization:
 
 All images use a consistent tag format with platform/OS identifiers and version information:
 
-**Pattern:** `{platform-identifier}-dotnet{X.Y}-workloads{exact-or-band}[-v{sha}]`
+**Pattern:** `{platform-identifier}-dotnet{X.Y}[-preview|-previewN|-rc|-rcN][-workloads{exact-or-band}][-v{sha}]`
 
 **Tag Variants:**
 
-1. **`{platform}-dotnet{X.Y}`** - Latest workload set for this .NET version
-2. **`{platform}-dotnet{X.Y}-workloads{X.Y.Z}`** - Specific workload version
-3. **`{platform}-dotnet{X.Y}-workloads{X.Y.Nxx}`** - Rolling workload-band tag for minor updates in a hundreds range
-4. **`{platform}-dotnet{X.Y}-workloads{X.Y.Z}-v{sha}`** - SHA-pinned build (optional)
+1. **`{platform}-dotnet{X.Y}`** - Latest stable workload set for this .NET version
+2. **`{platform}-dotnet{X.Y}-preview`** - Latest prerelease workload set for this .NET version
+3. **`{platform}-dotnet{X.Y}-previewN`** - Latest workload set for a specific preview wave
+4. **`{platform}-dotnet{tag}-workloads{X.Y.Z}`** - Specific workload version
+5. **`{platform}-dotnet{tag}-workloads{X.Y.Nxx}`** - Rolling workload-band tag for minor updates in a hundreds range
+6. **`{platform}-dotnet{specific-tag}-workloads{X.Y.Z}-v{sha}`** - SHA-pinned build (optional)
 
 ### Examples by Platform
 
@@ -77,10 +79,12 @@ maui-containers/maui-linux:dotnet10.0-workloads10.0.3xx
 maui-containers/maui-linux:dotnet10.0-workloads10.0.300.3-vsha256abc
 
 # .NET 11.0 Preview
-maui-containers/maui-linux:dotnet11.0
-maui-containers/maui-linux:dotnet11.0-workloads11.0.100-preview.4.26261.2
-maui-containers/maui-linux:dotnet11.0-workloads11.0.1xx
-maui-containers/maui-linux:dotnet11.0-workloads11.0.100-preview.4.26261.2-vsha256abc
+maui-containers/maui-linux:dotnet11.0-preview
+maui-containers/maui-linux:dotnet11.0-preview4
+maui-containers/maui-linux:dotnet11.0-preview-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-linux:dotnet11.0-preview-workloads11.0.1xx
+maui-containers/maui-linux:dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-linux:dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2-vsha256abc
 ```
 
 #### Windows Base Images
@@ -91,9 +95,12 @@ maui-containers/maui-windows:dotnet10.0-workloads10.0.300.3
 maui-containers/maui-windows:dotnet10.0-workloads10.0.300.3-vsha256abc
 
 # .NET 11.0 Preview
-maui-containers/maui-windows:dotnet11.0
-maui-containers/maui-windows:dotnet11.0-workloads11.0.100-preview.4.26261.2
-maui-containers/maui-windows:dotnet11.0-workloads11.0.100-preview.4.26261.2-vsha256abc
+maui-containers/maui-windows:dotnet11.0-preview
+maui-containers/maui-windows:dotnet11.0-preview4
+maui-containers/maui-windows:dotnet11.0-preview-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-windows:dotnet11.0-preview-workloads11.0.1xx
+maui-containers/maui-windows:dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-windows:dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2-vsha256abc
 ```
 
 #### macOS VM Images (includes OS version)
@@ -105,10 +112,12 @@ maui-containers/maui-macos:tahoe-dotnet10.0-workloads10.0.3xx
 maui-containers/maui-macos:tahoe-dotnet10.0-workloads10.0.300.3-vsha256abc
 
 # .NET 11.0 Preview
-maui-containers/maui-macos:tahoe-dotnet11.0
-maui-containers/maui-macos:tahoe-dotnet11.0-workloads11.0.100-preview.4.26261.2
-maui-containers/maui-macos:tahoe-dotnet11.0-workloads11.0.1xx
-maui-containers/maui-macos:tahoe-dotnet11.0-workloads11.0.100-preview.4.26261.2-vsha256abc
+maui-containers/maui-macos:tahoe-dotnet11.0-preview
+maui-containers/maui-macos:tahoe-dotnet11.0-preview4
+maui-containers/maui-macos:tahoe-dotnet11.0-preview-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-macos:tahoe-dotnet11.0-preview-workloads11.0.1xx
+maui-containers/maui-macos:tahoe-dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-macos:tahoe-dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2-vsha256abc
 ```
 
 #### Emulator/Test Images (includes Android API level)
@@ -118,8 +127,11 @@ maui-containers/maui-emulator-linux:android35-dotnet10.0
 maui-containers/maui-emulator-linux:android35-dotnet10.0-workloads10.0.300.3
 
 # Android 36 with .NET 11.0 Preview
-maui-containers/maui-emulator-linux:android36-dotnet11.0
-maui-containers/maui-emulator-linux:android36-dotnet11.0-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-emulator-linux:android36-dotnet11.0-preview
+maui-containers/maui-emulator-linux:android36-dotnet11.0-preview4
+maui-containers/maui-emulator-linux:android36-dotnet11.0-preview-workloads11.0.100-preview.4.26261.2
+maui-containers/maui-emulator-linux:android36-dotnet11.0-preview-workloads11.0.1xx
+maui-containers/maui-emulator-linux:android36-dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2
 ```
 
 ### Platform Identifiers
@@ -136,6 +148,7 @@ maui-containers/maui-emulator-linux:android36-dotnet11.0-workloads11.0.100-previ
 - **Always includes .NET version** - No ambiguity about which .NET version is installed
 - **Workload versions explicit** - Pin to specific workload sets for reproducible builds
 - **Rolling band tags available** - Follow updates like `10.0.3xx` or `11.0.1xx` without jumping across bands
+- **Prerelease tags are explicit** - Preview and RC channels always include `-preview`, `-previewN`, `-rc`, or `-rcN`
 - **SHA pinning optional** - For maximum reproducibility when needed
 - **Platform-aware** - macOS includes OS version for Xcode; emulator includes API level
 - **No redundant tags** - Removed ambiguous `:latest` and platform-only tags
@@ -155,7 +168,7 @@ Development images provide a complete .NET MAUI development environment. Use the
 docker run -it maui-containers/maui-linux:dotnet10.0 bash
 
 # Run a Windows development container (.NET 11.0 Preview)
-docker run -it maui-containers/maui-windows:dotnet11.0 powershell
+docker run -it maui-containers/maui-windows:dotnet11.0-preview powershell
 ```
 
 **With Custom Startup Logic:**
@@ -328,7 +341,7 @@ Each Android API Level (23 through latest) has its own image variant.  You can s
 <summary>Show Active Variant Examples...</summary>
 
 - ![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android35-dotnet10.0?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
-- ![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android36-dotnet11.0?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
+- ![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android36-dotnet11.0-preview?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
  
 </details>
 
@@ -356,9 +369,11 @@ Tart VM images provide complete macOS virtual machines for .NET MAUI development
 - `tahoe-dotnet10.0` - .NET 10.0 on macOS Tahoe
 - `tahoe-dotnet10.0-workloads10.0.300.3` - Specific workload version
 - `tahoe-dotnet10.0-workloads10.0.3xx` - Rolling tag for the 10.0.300-399 workload band
-- `tahoe-dotnet11.0` - .NET 11.0 Preview on macOS Tahoe
-- `tahoe-dotnet11.0-workloads11.0.100-preview.4.26261.2` - Specific workload version
-- `tahoe-dotnet11.0-workloads11.0.1xx` - Rolling tag for the 11.0.100 preview workload band
+- `tahoe-dotnet11.0-preview` - Latest .NET 11.0 preview on macOS Tahoe
+- `tahoe-dotnet11.0-preview4` - Latest .NET 11.0 Preview 4 on macOS Tahoe
+- `tahoe-dotnet11.0-preview-workloads11.0.100-preview.4.26261.2` - Specific workload version on the preview channel
+- `tahoe-dotnet11.0-preview-workloads11.0.1xx` - Rolling tag for the 11.0.100 preview workload band
+- `tahoe-dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2` - Specific workload version pinned to Preview 4
 
 Images are automatically built and published to GitHub Container Registry (ghcr.io) when workload updates are detected or when manually triggered.
 
@@ -375,7 +390,7 @@ tart run maui-dev
 tart run ghcr.io/maui-containers/maui-macos:tahoe-dotnet10.0
 
 # Pin to a specific workload version
-tart clone ghcr.io/maui-containers/maui-macos:tahoe-dotnet11.0-workloads11.0.100-preview.4.26261.2 maui-dev
+tart clone ghcr.io/maui-containers/maui-macos:tahoe-dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2 maui-dev
 ```
 
 ### Custom Startup

--- a/check-workload-updates.ps1
+++ b/check-workload-updates.ps1
@@ -22,19 +22,10 @@
     The test Docker repository to check for existing tags. Defaults to "ghcr.io/maui-containers/maui-emulator-linux".
 
 .PARAMETER TagPattern
-    The tag pattern to look for. The script will replace placeholders with actual values:
-    - {platform}: 'linux' or 'windows' 
-    - {dotnet_version}: The .NET version (e.g., '10.0')
-    - {workload_version}: The workload set version (e.g., '10.0.300.3')
-    Defaults to "{platform}-dotnet{dotnet_version}-workloads{workload_version}".
+    Deprecated compatibility parameter. Expected base image tags are generated from the shared tag helpers.
 
 .PARAMETER TestTagPattern
-    The test tag pattern to look for. Includes Android API level support:
-    - {platform}: 'appium-emulator-linux'
-    - {dotnet_version}: The .NET version (e.g., '10.0')
-    - {workload_version}: The workload set version (e.g., '10.0.300.3')
-    - {api_level}: Android API level (e.g., '35')
-    Defaults to "{platform}-dotnet{dotnet_version}-workloads{workload_version}-android{api_level}".
+    Deprecated compatibility parameter. Expected emulator tags are generated from the shared tag helpers.
 
 .PARAMETER OutputFormat
     The output format. Use "github-actions" for GitHub Actions environment variables,
@@ -177,19 +168,18 @@ function Test-TestRepositoryBuilds {
 
         Write-HostWithPrefix "Found $($existingTags.Count) test repository tags"
         
-        # Create test tag patterns for common API levels (we check for any Android API level)
-        # The test tag pattern is: appium-emulator-linux-dotnet{version}-workloads{workload}-android{api}
-        $testPlatform = "appium-emulator-linux"
-        $testTagPattern = $TagPattern -replace '\{platform\}', $testPlatform -replace '\{dotnet_version\}', $DotnetVersion -replace '\{workload_version\}', $WorkloadVersion
+        # Check for any Android API level using the exact workload tag emitted by docker/test/build.ps1.
+        $dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetVersion -WorkloadVersion $WorkloadVersion
+        $testTagPattern = "android\d+-$([regex]::Escape($dotnetTagPrefixInfo.Channel))-workloads$([regex]::Escape($WorkloadVersion))"
         
         # Check if any tag matches the pattern with any API level
         $matchingTags = $existingTags | Where-Object { 
-            $_ -match "^$($testTagPattern -replace '\{api_level\}', '\d+')" 
+            $_ -match "^$testTagPattern$"
         }
         
         $hasTestBuilds = $matchingTags.Count -gt 0
         
-        Write-HostWithPrefix "Test tag pattern (with API level): $($testTagPattern -replace '\{api_level\}', 'XX')"
+        Write-HostWithPrefix "Test tag pattern (with API level): $($testTagPattern -replace '\\d\+', 'XX')"
         Write-HostWithPrefix "Matching test tags found: $($matchingTags.Count)"
         if ($matchingTags.Count -gt 0 -and $matchingTags.Count -le 5) {
             Write-HostWithPrefix "Sample matching tags: $($matchingTags -join ', ')"
@@ -214,9 +204,9 @@ function Test-BaseRepositoryBuilds {
         [string]$WorkloadVersion
     )
     
-    # Build the expected tag format (without platform prefix)
-    # Actual tags are: dotnet{version}-workloads{workload_version}
-    $expectedTag = "dotnet$DotnetVersion-workloads$WorkloadVersion"
+    # Build the expected tag format emitted by docker/build.ps1.
+    $dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetVersion -WorkloadVersion $WorkloadVersion
+    $expectedTag = "$($dotnetTagPrefixInfo.Channel)-workloads$WorkloadVersion"
     
     Write-HostWithPrefix "Checking Linux repository: $LinuxRepository"
     $hasLinuxBase = $false
@@ -377,9 +367,10 @@ try {
         Write-HostWithPrefix "Warning: iOS workload information not found in workload set data"
     }
 
-    # Create expected tag patterns for both platforms
-    $linuxTag = $TagPattern -replace '\{platform\}', 'linux' -replace '\{dotnet_version\}', $DotnetVersion -replace '\{workload_version\}', $dotnetCommandWorkloadSetVersion
-    $windowsTag = $TagPattern -replace '\{platform\}', 'windows' -replace '\{dotnet_version\}', $DotnetVersion -replace '\{workload_version\}', $dotnetCommandWorkloadSetVersion
+    # Create expected exact workload tags for both platform repositories.
+    $dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetVersion -WorkloadVersion $dotnetCommandWorkloadSetVersion
+    $linuxTag = "$($dotnetTagPrefixInfo.Channel)-workloads$dotnetCommandWorkloadSetVersion"
+    $windowsTag = $linuxTag
     
     Write-HostWithPrefix "Looking for Linux tag: $linuxTag"
     Write-HostWithPrefix "Looking for Windows tag: $windowsTag"
@@ -431,8 +422,9 @@ try {
         
         # In error case, still set the tag values if we have them
         if ($latestVersion -and $dotnetCommandWorkloadSetVersion) {
-            $linuxTag = $TagPattern -replace '\{platform\}', 'linux' -replace '\{dotnet_version\}', $DotnetVersion -replace '\{workload_version\}', $dotnetCommandWorkloadSetVersion
-            $windowsTag = $TagPattern -replace '\{platform\}', 'windows' -replace '\{dotnet_version\}', $DotnetVersion -replace '\{workload_version\}', $dotnetCommandWorkloadSetVersion
+            $dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetVersion -WorkloadVersion $dotnetCommandWorkloadSetVersion
+            $linuxTag = "$($dotnetTagPrefixInfo.Channel)-workloads$dotnetCommandWorkloadSetVersion"
+            $windowsTag = $linuxTag
         }
         
         # Always trigger builds on error or when force build is specified

--- a/common-functions.ps1
+++ b/common-functions.ps1
@@ -389,6 +389,82 @@ function Get-WorkloadBandTag {
     return "$majorVersion.$minorVersion.$bandAlias"
 }
 
+function Get-DotnetPrereleaseTagSuffixes {
+    param (
+        [string]$Version
+    )
+
+    $result = [PSCustomObject]@{
+        IsPrerelease = $false
+        ChannelSuffix = ""
+        SpecificSuffix = ""
+        Label = ""
+        Number = ""
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        return $result
+    }
+
+    if ($Version -notmatch '^[^-]+-(?<label>[A-Za-z][A-Za-z0-9]*)(?:\.(?<number>\d+))?') {
+        return $result
+    }
+
+    $label = $Matches['label'].ToLowerInvariant()
+    $number = ""
+    if ($Matches.ContainsKey('number')) {
+        $number = $Matches['number']
+    }
+
+    $specificSuffix = "-$label"
+    if (-not [string]::IsNullOrWhiteSpace($number)) {
+        $specificSuffix = "-$label$number"
+    }
+
+    return [PSCustomObject]@{
+        IsPrerelease = $true
+        ChannelSuffix = "-$label"
+        SpecificSuffix = $specificSuffix
+        Label = $label
+        Number = $number
+    }
+}
+
+function Get-DotnetTagPrefixInfo {
+    param (
+        [string]$DotnetVersion,
+        [string]$WorkloadVersion,
+        [string]$Prefix = ""
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DotnetVersion)) {
+        throw "DotnetVersion is required to build image tags."
+    }
+
+    $baseTag = "${Prefix}dotnet$DotnetVersion"
+    $prereleaseSuffixes = Get-DotnetPrereleaseTagSuffixes -Version $WorkloadVersion
+
+    if (-not $prereleaseSuffixes.IsPrerelease) {
+        return [PSCustomObject]@{
+            Base = $baseTag
+            Channel = $baseTag
+            Specific = $baseTag
+            IsPrerelease = $false
+            PrereleaseLabel = ""
+            PrereleaseNumber = ""
+        }
+    }
+
+    return [PSCustomObject]@{
+        Base = $baseTag
+        Channel = "$baseTag$($prereleaseSuffixes.ChannelSuffix)"
+        Specific = "$baseTag$($prereleaseSuffixes.SpecificSuffix)"
+        IsPrerelease = $true
+        PrereleaseLabel = $prereleaseSuffixes.Label
+        PrereleaseNumber = $prereleaseSuffixes.Number
+    }
+}
+
 function Get-DotnetContainerImageTags {
     param (
         [string]$DotnetVersion,

--- a/docker/build.ps1
+++ b/docker/build.ps1
@@ -83,39 +83,53 @@ if (-not (Test-Path -Path $contextPath -PathType Container)) {
 Write-Host "Using build context: $contextPath"
 
 # Build tags following the unified naming scheme:
-# - dotnet{X.Y} - Latest workload for this .NET version
-# - dotnet{X.Y}-workloads{X.Y.Z} - Specific workload version
-# - dotnet{X.Y}-workloads{X.Y.Nxx} - Rolling workload band alias (e.g. 10.0.2xx)
-# - dotnet{X.Y}-workloads{X.Y.Z}-v{sha} - SHA-pinned version (optional)
+# - dotnet{X.Y} for stable, dotnet{X.Y}-{prerelease} for prerelease channels
+# - dotnet{X.Y}-{prereleaseN} for a specific prerelease wave
+# - dotnet{tag}-workloads{X.Y.Z} - Specific workload version
+# - dotnet{tag}-workloads{X.Y.Nxx} - Rolling workload band alias (e.g. 10.0.2xx)
+# - dotnet{specific-tag}-workloads{X.Y.Z}-v{sha} - SHA-pinned version (optional)
 # If Version is not "latest", also add a custom version tag
 $tags = @()
 $workloadBandTagVersion = Get-WorkloadBandTag -WorkloadVersion $dotnetCommandWorkloadSetVersion
+$dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetVersion -WorkloadVersion $dotnetCommandWorkloadSetVersion
 
-# 1. dotnet{X.Y} tag (this is the "latest" for this .NET version)
-$dotnetTag = "$DockerRepository`:dotnet$DotnetVersion"
+# 1. dotnet{tag} tag (this is the "latest" for this .NET version/channel)
+$dotnetTag = "$($DockerRepository):$($dotnetTagPrefixInfo.Channel)"
 $tags += $dotnetTag
 
-# 2. dotnet{X.Y}-workloads{X.Y.Z} tag
-$workloadTag = "$DockerRepository`:dotnet$DotnetVersion-workloads$dotnetCommandWorkloadSetVersion"
+# 2. Optional: dotnet{specific-prerelease} tag (e.g. dotnet11.0-preview4)
+if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
+    $specificDotnetTag = "$($DockerRepository):$($dotnetTagPrefixInfo.Specific)"
+    $tags += $specificDotnetTag
+}
+
+# 3. dotnet{tag}-workloads{X.Y.Z} tag
+$workloadTag = "$($DockerRepository):$($dotnetTagPrefixInfo.Channel)-workloads$dotnetCommandWorkloadSetVersion"
 $tags += $workloadTag
 
-# 3. Optional: dotnet{X.Y}-workloads{X.Y.Nxx} rolling band tag
+# 4. Optional: dotnet{tag}-workloads{X.Y.Nxx} rolling band tag
 if ($workloadBandTagVersion) {
-    $workloadBandTag = "$DockerRepository`:dotnet$DotnetVersion-workloads$workloadBandTagVersion"
+    $workloadBandTag = "$($DockerRepository):$($dotnetTagPrefixInfo.Channel)-workloads$workloadBandTagVersion"
     if ($tags -notcontains $workloadBandTag) {
         $tags += $workloadBandTag
     }
 }
 
-# 4. Optional: dotnet{X.Y}-workloads{X.Y.Z}-v{sha} tag
+# 5. Optional: dotnet{specific-prerelease}-workloads{X.Y.Z} tag
+if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
+    $specificWorkloadTag = "$($DockerRepository):$($dotnetTagPrefixInfo.Specific)-workloads$dotnetCommandWorkloadSetVersion"
+    $tags += $specificWorkloadTag
+}
+
+# 6. Optional: dotnet{specific-tag}-workloads{X.Y.Z}-v{sha} tag
 if ($BuildSha) {
-    $shaTag = "$DockerRepository`:dotnet$DotnetVersion-workloads$dotnetCommandWorkloadSetVersion-v$BuildSha"
+    $shaTag = "$($DockerRepository):$($dotnetTagPrefixInfo.Specific)-workloads$dotnetCommandWorkloadSetVersion-v$BuildSha"
     $tags += $shaTag
 }
 
-# 5. Optional: Custom version tag (for PR builds, etc.)
+# 7. Optional: Custom version tag (for PR builds, etc.)
 if ($Version -ne "latest") {
-    $customTag = "$DockerRepository`:dotnet$DotnetVersion-$Version"
+    $customTag = "$($DockerRepository):$($dotnetTagPrefixInfo.Specific)-$Version"
     $tags += $customTag
 }
 

--- a/docker/test/build.ps1
+++ b/docker/test/build.ps1
@@ -134,29 +134,52 @@ Write-Host "Using Android SDK API Level: $AndroidSdkApiLevel (from parameter/mat
 Write-Host "Workload default API Level: $($androidDetails.ApiLevel) (will be available in the built image)"
 
 # Build tags following the unified naming scheme:
-# - android{XX}-dotnet{X.Y} - Latest workload for this .NET version
-# - android{XX}-dotnet{X.Y}-workloads{X.Y.Z} - Specific workload version
-# - android{XX}-dotnet{X.Y}-workloads{X.Y.Z}-v{sha} - SHA-pinned version (optional)
+# - android{XX}-dotnet{X.Y} for stable, android{XX}-dotnet{X.Y}-{prerelease} for prerelease channels
+# - android{XX}-dotnet{X.Y}-{prereleaseN} for a specific prerelease wave
+# - android{XX}-dotnet{tag}-workloads{X.Y.Z} - Specific workload version
+# - android{XX}-dotnet{specific-tag}-workloads{X.Y.Z}-v{sha} - SHA-pinned version (optional)
 # If Version is not "latest", also add a custom version tag
 $tags = @()
+$workloadBandTagVersion = Get-WorkloadBandTag -WorkloadVersion $dotnetCommandWorkloadSetVersion
+$dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetVersion -WorkloadVersion $dotnetCommandWorkloadSetVersion -Prefix "android${AndroidSdkApiLevel}-"
 
-# 1. android{XX}-dotnet{X.Y} tag (this is the "latest" for this .NET version + API level)
-$dotnetTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}"
+# 1. android{XX}-dotnet{tag} tag (this is the "latest" for this .NET version/channel + API level)
+$dotnetTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Channel)"
 $tags += $dotnetTag
 
-# 2. android{XX}-dotnet{X.Y}-workloads{X.Y.Z} tag
-$workloadTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}-workloads${dotnetCommandWorkloadSetVersion}"
+# 2. Optional: android{XX}-dotnet{specific-prerelease} tag (e.g. android36-dotnet11.0-preview4)
+if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
+    $specificDotnetTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)"
+    $tags += $specificDotnetTag
+}
+
+# 3. android{XX}-dotnet{tag}-workloads{X.Y.Z} tag
+$workloadTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Channel)-workloads${dotnetCommandWorkloadSetVersion}"
 $tags += $workloadTag
 
-# 3. Optional: android{XX}-dotnet{X.Y}-workloads{X.Y.Z}-v{sha} tag
+# 4. Optional: prerelease rolling workload band tag
+if ($dotnetTagPrefixInfo.IsPrerelease -and $workloadBandTagVersion) {
+    $workloadBandTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Channel)-workloads${workloadBandTagVersion}"
+    if ($tags -notcontains $workloadBandTag) {
+        $tags += $workloadBandTag
+    }
+}
+
+# 5. Optional: android{XX}-dotnet{specific-prerelease}-workloads{X.Y.Z} tag
+if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
+    $specificWorkloadTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)-workloads${dotnetCommandWorkloadSetVersion}"
+    $tags += $specificWorkloadTag
+}
+
+# 6. Optional: android{XX}-dotnet{specific-tag}-workloads{X.Y.Z}-v{sha} tag
 if ($BuildSha) {
-    $shaTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}-workloads${dotnetCommandWorkloadSetVersion}-v${BuildSha}"
+    $shaTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)-workloads${dotnetCommandWorkloadSetVersion}-v${BuildSha}"
     $tags += $shaTag
 }
 
-# 4. Optional: Custom version tag (for PR builds, etc.)
+# 7. Optional: Custom version tag (for PR builds, etc.)
 if ($Version -ne "latest") {
-    $customTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}-${Version}"
+    $customTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)-${Version}"
     $tags += $customTag
 }
 

--- a/docker/test/run.ps1
+++ b/docker/test/run.ps1
@@ -19,6 +19,14 @@ Param(
     [String]$AvdName = ""
 )
 
+$commonFunctionsPath = Join-Path -Path $PSScriptRoot -ChildPath "..\..\common-functions.ps1" -Resolve -ErrorAction SilentlyContinue
+if ($commonFunctionsPath -and (Test-Path -Path $commonFunctionsPath -PathType Leaf)) {
+    . $commonFunctionsPath
+} else {
+    Write-Error "Could not find common functions file at expected path: ..\..\common-functions.ps1"
+    exit 1
+}
+
 $runArgs = @(
     "run", "-d",
     "--device", "/dev/kvm",
@@ -59,7 +67,8 @@ if ($AvdName -ne "") {
     $runArgs += "-e", "AVD_NAME=$AvdName"
 }
 
-$imageTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}"
+$dotnetImageTags = Get-DotnetContainerImageTags -DotnetVersion $DotnetVersion -DockerPlatform "linux/amd64"
+$imageTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet$($dotnetImageTags.ImageVersion)"
 $runArgs += $imageTag
 
 Write-Host "Starting emulator container: docker $($runArgs -join ' ')"

--- a/tart/macos/CLAUDE.md
+++ b/tart/macos/CLAUDE.md
@@ -215,7 +215,7 @@ Tart VM images are automatically published to GitHub Container Registry (ghcr.io
 
 **Published Image Locations:**
 - `ghcr.io/maui-containers/maui-macos:tahoe-dotnet10.0` - .NET 10.0 MAUI development VM
-- `ghcr.io/maui-containers/maui-macos:tahoe-dotnet11.0` - .NET 11.0 Preview MAUI development VM
+- `ghcr.io/maui-containers/maui-macos:tahoe-dotnet11.0-preview` - .NET 11.0 Preview MAUI development VM
 
 **Authentication:** GitHub Actions uses `GITHUB_TOKEN` automatically. For local use, you need a GitHub Personal Access Token with `packages:write` permission.
 

--- a/tart/macos/scripts/build.ps1
+++ b/tart/macos/scripts/build.ps1
@@ -394,6 +394,97 @@ function Start-TartBuild {
     }
 }
 
+function Get-TartRegistryTags {
+    param(
+        [string]$ImageName,
+        [string]$RegistryImageName,
+        [string]$Registry,
+        [string]$WorkloadSetVersion,
+        [string]$MacOSVersion,
+        [string]$DotnetChannel,
+        [string]$BaseXcodeVersion,
+        [string]$BuildSha
+    )
+
+    if (-not $MacOSVersion -or -not $DotnetChannel) {
+        throw "MacOSVersion and DotnetChannel are required for image tagging"
+    }
+
+    if (-not $Registry) {
+        return @()
+    }
+
+    $registryName = if ($RegistryImageName) { $RegistryImageName } else { $ImageName }
+    $registryPrefix = "$Registry/${registryName}:"
+    $tags = [System.Collections.Generic.List[string]]::new()
+
+    function Add-RegistryTag {
+        param([string]$TagName)
+
+        $tagRef = "$registryPrefix$TagName"
+        if (-not $tags.Contains($tagRef)) {
+            [void]$tags.Add($tagRef)
+        }
+    }
+
+    $xcodeVersionTag = ""
+    if ($BaseXcodeVersion) {
+        if (-not $BaseXcodeVersion.StartsWith("@")) {
+            $xcodeVersionTag = $BaseXcodeVersion -replace '[^0-9.]', ''
+        }
+    }
+
+    $dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetChannel -WorkloadVersion $WorkloadSetVersion -Prefix "$MacOSVersion-"
+    $workloadBandTagVersion = Get-WorkloadBandTag -WorkloadVersion $WorkloadSetVersion
+
+    Add-RegistryTag -TagName $dotnetTagPrefixInfo.Channel
+    if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
+        Add-RegistryTag -TagName $dotnetTagPrefixInfo.Specific
+    }
+
+    if ($xcodeVersionTag) {
+        $xcodeChannelTag = "$($dotnetTagPrefixInfo.Channel)-xcode$xcodeVersionTag"
+        $xcodeSpecificTag = "$($dotnetTagPrefixInfo.Specific)-xcode$xcodeVersionTag"
+
+        Add-RegistryTag -TagName $xcodeChannelTag
+        if ($xcodeSpecificTag -ne $xcodeChannelTag) {
+            Add-RegistryTag -TagName $xcodeSpecificTag
+        }
+
+        if ($WorkloadSetVersion) {
+            Add-RegistryTag -TagName "$xcodeChannelTag-workloads$WorkloadSetVersion"
+
+            if ($workloadBandTagVersion) {
+                Add-RegistryTag -TagName "$xcodeChannelTag-workloads$workloadBandTagVersion"
+            }
+
+            if ($xcodeSpecificTag -ne $xcodeChannelTag) {
+                Add-RegistryTag -TagName "$xcodeSpecificTag-workloads$WorkloadSetVersion"
+            }
+
+            if ($BuildSha) {
+                Add-RegistryTag -TagName "$xcodeSpecificTag-workloads$WorkloadSetVersion-v$BuildSha"
+            }
+        }
+    } elseif ($WorkloadSetVersion) {
+        Add-RegistryTag -TagName "$($dotnetTagPrefixInfo.Channel)-workloads$WorkloadSetVersion"
+
+        if ($workloadBandTagVersion) {
+            Add-RegistryTag -TagName "$($dotnetTagPrefixInfo.Channel)-workloads$workloadBandTagVersion"
+        }
+
+        if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
+            Add-RegistryTag -TagName "$($dotnetTagPrefixInfo.Specific)-workloads$WorkloadSetVersion"
+        }
+
+        if ($BuildSha) {
+            Add-RegistryTag -TagName "$($dotnetTagPrefixInfo.Specific)-workloads$WorkloadSetVersion-v$BuildSha"
+        }
+    }
+
+    return $tags.ToArray()
+}
+
 function Push-TartImage {
     param(
         [string]$ImageName,
@@ -411,82 +502,7 @@ function Push-TartImage {
         return
     }
 
-    # Build list of tags to push in the format:
-    # :{macos}-dotnet{version} (always - this is the "latest" for this .NET version)
-    # :{macos}-dotnet{version}-xcode{version} (if Xcode version known)
-    # :{macos}-dotnet{version}-xcode{version}-workloads{workloadversion} (if both known)
-    # :{macos}-dotnet{version}-xcode{version}-workloads{band}xx (rolling workload band alias)
-    # :{macos}-dotnet{version}-xcode{version}-workloads{workloadversion}-v{sha} (if SHA provided)
-    $tags = @()
-
-    # Validate required components
-    if (-not $MacOSVersion -or -not $DotnetChannel) {
-        throw "MacOSVersion and DotnetChannel are required for image tagging"
-    }
-
-    # Use RegistryImageName for the registry path if provided, otherwise fall back to ImageName
-    $registryName = if ($RegistryImageName) { $RegistryImageName } else { $ImageName }
-
-    # Normalize Xcode version (strip @ prefix if it's a digest, extract version number)
-    $xcodeVersionTag = ""
-    if ($BaseXcodeVersion) {
-        if ($BaseXcodeVersion.StartsWith("@")) {
-            # If it's a digest, we can't use it in tag - skip Xcode-specific tags
-            Write-Host "Base Xcode version is a digest - skipping Xcode-specific tags"
-        } else {
-            # Clean version like "26.1" or "16.4"
-            $xcodeVersionTag = $BaseXcodeVersion -replace '[^0-9.]', ''
-        }
-    }
-
-    $workloadBandTagVersion = Get-WorkloadBandTag -WorkloadVersion $WorkloadSetVersion
-
-    # 1. macOS + .NET version tag (e.g., :tahoe-dotnet10.0) - this is the "latest" for this .NET version
-    $baseTag = "$MacOSVersion-dotnet$DotnetChannel"
-    $tags += "$Registry/${registryName}:$baseTag"
-
-    # 2. macOS + .NET + Xcode tag (e.g., :tahoe-dotnet10.0-xcode26.1)
-    if ($xcodeVersionTag) {
-        $xcodeTag = "$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag"
-        $tags += "$Registry/${registryName}:$xcodeTag"
-
-        # 3. macOS + .NET + Xcode + Workload tag (e.g., :tahoe-dotnet10.0-xcode26.1-workloads10.0.100.1)
-        if ($WorkloadSetVersion) {
-            $fullTag = "$xcodeTag-workloads$WorkloadSetVersion"
-            $tags += "$Registry/${registryName}:$fullTag"
-
-            if ($workloadBandTagVersion) {
-                $bandTag = "$xcodeTag-workloads$workloadBandTagVersion"
-                $bandTagRef = "$Registry/${registryName}:$bandTag"
-                if ($tags -notcontains $bandTagRef) {
-                    $tags += $bandTagRef
-                }
-            }
-
-            # 4. Add SHA-pinned tag if BuildSha is provided (e.g., :tahoe-dotnet10.0-xcode26.1-workloads10.0.100.1-vabc12345)
-            if ($BuildSha) {
-                $shaTag = "$fullTag-v$BuildSha"
-                $tags += "$Registry/${registryName}:$shaTag"
-            }
-        }
-    } elseif ($WorkloadSetVersion) {
-        # Fallback: If no Xcode version tag but we have workloads, use old format
-        $workloadTag = "$MacOSVersion-dotnet$DotnetChannel-workloads$WorkloadSetVersion"
-        $tags += "$Registry/${registryName}:$workloadTag"
-
-        if ($workloadBandTagVersion) {
-            $bandTag = "$MacOSVersion-dotnet$DotnetChannel-workloads$workloadBandTagVersion"
-            $bandTagRef = "$Registry/${registryName}:$bandTag"
-            if ($tags -notcontains $bandTagRef) {
-                $tags += $bandTagRef
-            }
-        }
-
-        if ($BuildSha) {
-            $shaTag = "$workloadTag-v$BuildSha"
-            $tags += "$Registry/${registryName}:$shaTag"
-        }
-    }
+    $tags = Get-TartRegistryTags -ImageName $ImageName -RegistryImageName $RegistryImageName -Registry $Registry -WorkloadSetVersion $WorkloadSetVersion -MacOSVersion $MacOSVersion -DotnetChannel $DotnetChannel -BaseXcodeVersion $BaseXcodeVersion -BuildSha $BuildSha
 
     if ($DryRun) {
         Write-Host "[DryRun] Would push image with tags:"
@@ -622,42 +638,15 @@ try {
     }
     Write-Host "Local image name: $ImageName"
 
-    # Use RegistryImageName for display if it was provided and we're pushing
-    $displayRegistryName = if ($RegistryImageName -and (($Push -or $PushOnly) -and $Registry)) { $RegistryImageName } else { $ImageName }
-
-    # Normalize Xcode version for display
-    $xcodeVersionTag = ""
-    if ($BaseXcodeVersion -and -not $BaseXcodeVersion.StartsWith("@")) {
-        $xcodeVersionTag = $BaseXcodeVersion -replace '[^0-9.]', ''
-    }
-    $resolvedWorkloadBandTag = Get-WorkloadBandTag -WorkloadVersion $resolvedWorkloadSetVersion
+    $publishedTags = if ($Registry) {
+        Get-TartRegistryTags -ImageName $ImageName -RegistryImageName $RegistryImageName -Registry $Registry -WorkloadSetVersion $resolvedWorkloadSetVersion -MacOSVersion $MacOSVersion -DotnetChannel $DotnetChannel -BaseXcodeVersion $BaseXcodeVersion -BuildSha $BuildSha
+    } else { @() }
 
     if (($Push -or $PushOnly) -and $Registry) {
         Write-Host ""
         Write-Host "Published tags:"
-        Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel"
-
-        if ($xcodeVersionTag) {
-            Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag"
-
-            if ($resolvedWorkloadSetVersion) {
-                Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion"
-                if ($resolvedWorkloadBandTag) {
-                    Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadBandTag"
-                }
-                if ($BuildSha) {
-                    Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion-v$BuildSha"
-                }
-            }
-        } elseif ($resolvedWorkloadSetVersion) {
-            # Fallback format if no Xcode version
-            Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion"
-            if ($resolvedWorkloadBandTag) {
-                Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadBandTag"
-            }
-            if ($BuildSha) {
-                Write-Host "  $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion-v$BuildSha"
-            }
+        foreach ($tag in $publishedTags) {
+            Write-Host "  $tag"
         }
     }
 
@@ -672,24 +661,8 @@ try {
         if ($Registry) {
             Write-Host ""
             Write-Host "To pull from registry:"
-            Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel"
-
-            if ($xcodeVersionTag -and $resolvedWorkloadSetVersion) {
-                Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion"
-                if ($resolvedWorkloadBandTag) {
-                    Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadBandTag"
-                }
-                if ($BuildSha) {
-                    Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-xcode$xcodeVersionTag-workloads$resolvedWorkloadSetVersion-v$BuildSha"
-                }
-            } elseif ($resolvedWorkloadSetVersion) {
-                Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion"
-                if ($resolvedWorkloadBandTag) {
-                    Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadBandTag"
-                }
-                if ($BuildSha) {
-                    Write-Host "  tart pull $Registry/${displayRegistryName}:$MacOSVersion-dotnet$DotnetChannel-workloads$resolvedWorkloadSetVersion-v$BuildSha"
-                }
+            foreach ($tag in $publishedTags) {
+                Write-Host "  tart pull $tag"
             }
         }
     }


### PR DESCRIPTION
Preview .NET channels should not publish bare tags like `dotnet11.0`, because those look stable even when the underlying SDK/workload set is prerelease.

This updates tag generation so prerelease workload versions produce explicit channel and wave tags such as `dotnet11.0-preview` and `dotnet11.0-preview4`, while stable channels keep the existing `dotnet10.0` format. The shared tag helpers are reused by Docker base images, emulator images, Tart macOS publishing, workload update detection, and documentation so the behavior stays consistent across image families.

Notable behavior:
- Exact prerelease workload tags are published on the prerelease channel, for example `dotnet11.0-preview-workloads11.0.100-preview.4.26261.2`.
- Specific preview wave tags are also published for pinning, for example `dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2`.
- Stable workload tags are unchanged.