### PR TITLE
Decouple emulator images from .NET workload versions

### DIFF
--- a/.github/workflows/build-emulators.yml
+++ b/.github/workflows/build-emulators.yml
@@ -3,15 +3,6 @@ name: 🐋 Build Android Emulator Images
 on:
   workflow_dispatch:
     inputs:
-      workload_set_version:
-        description: 'Specific workload set version to use'
-        required: false
-        type: string
-      dotnet_versions:
-        description: 'JSON array of .NET versions to build (e.g., ["10.0", "11.0"])'
-        required: false
-        type: string
-        default: '["10.0", "11.0"]'
       android_api_levels:
         description: 'JSON array of Android API levels to build (e.g., [34, 35])'
         required: false
@@ -33,136 +24,47 @@ permissions:
   packages: write
 
 jobs:
-  get-workload-info:
-    name: 🔍 Get Workload Information
+  determine-matrix:
+    name: 🎯 Determine Emulator Matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.determine-matrix.outputs.matrix }}
-      workload-api-levels: ${{ steps.get-workload-info.outputs.workload-api-levels }}
-      workload-set-version: ${{ steps.vars.outputs.workload_set_version }}
-    
-    steps:
-    - name: 🛒 Checkout
-      uses: actions/checkout@v4
 
-    - name: 🔧 Set Variables
-      id: vars
-      run: |
-        # Determine workload set version from either workflow_dispatch input or repository_dispatch payload
-        if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-          WORKLOAD_SET_VERSION="${{ github.event.client_payload.workload_set_version }}"
-        else
-          WORKLOAD_SET_VERSION="${{ inputs.workload_set_version }}"
-        fi
-        echo "workload_set_version=$WORKLOAD_SET_VERSION" >> $GITHUB_OUTPUT
-        echo "Using workload set version: $WORKLOAD_SET_VERSION"
-    
-    - name: 🔍 Get Workload Information
-      id: get-workload-info
-      shell: pwsh
-      run: |
-        # Import common functions
-        . ./common-functions.ps1
-        
-        # Define .NET versions to check
-        $dotnetVersionsInput = '${{ inputs.dotnet_versions }}'
-        $dotnetVersions = if ($dotnetVersionsInput -ne "") {
-          $dotnetVersionsInput | ConvertFrom-Json
-        } else {
-          # .NET 9.0 is retired from active builds. Add it here if it needs to be revived.
-          @("10.0", "11.0")
-        }
-        $workloadApiLevels = @{}
-        
-        foreach ($dotnetVersion in $dotnetVersions) {
-          Write-Host "Getting workload information for .NET $dotnetVersion"
-          $workloadInfo = Get-WorkloadInfo -DotnetVersion $dotnetVersion -WorkloadSetVersion "${{ steps.vars.outputs.workload_set_version }}" -IncludeAndroid -DockerPlatform "linux/amd64"
-          
-          if ($workloadInfo -and $workloadInfo.Workloads["Microsoft.NET.Sdk.Android"] -and $workloadInfo.Workloads["Microsoft.NET.Sdk.Android"].Details) {
-            $workloadApiLevel = $workloadInfo.Workloads["Microsoft.NET.Sdk.Android"].Details.ApiLevel
-            $workloadApiLevels[$dotnetVersion] = $workloadApiLevel
-            Write-Host "Workload for .NET $dotnetVersion requires API Level: $workloadApiLevel"
-          } else {
-            Write-Warning "Could not get workload API level for .NET $dotnetVersion, using default"
-            $workloadApiLevels[$dotnetVersion] = 35
-          }
-        }
-        
-        # Output the workload API levels as JSON
-        $workloadApiLevelsJson = $workloadApiLevels | ConvertTo-Json -Compress
-        echo "workload-api-levels=$workloadApiLevelsJson" >> $env:GITHUB_OUTPUT
-    
-    - name: 🎯 Determine Build Matrix
+    steps:
+    - name: 🎯 Determine Emulator Matrix
       id: determine-matrix
       shell: pwsh
       run: |
-        # Parse workload API levels
-        $workloadApiLevels = '${{ steps.get-workload-info.outputs.workload-api-levels }}' | ConvertFrom-Json
-        
-        # Define .NET versions to use
-        $dotnetVersionsInput = '${{ inputs.dotnet_versions }}'
-        $dotnetVersions = if ($dotnetVersionsInput -ne "") {
-          $dotnetVersionsInput | ConvertFrom-Json
+        if ("${{ github.event_name }}" -eq "repository_dispatch") {
+          $apiLevelsInput = '${{ github.event.client_payload.android_api_levels }}'
         } else {
-          # .NET 9.0 is retired from active builds. Add it here if it needs to be revived.
-          @("10.0", "11.0")
+          $apiLevelsInput = '${{ inputs.android_api_levels }}'
         }
-        
-        # Define API levels to use
-        $apiLevelsInput = '${{ inputs.android_api_levels }}'
-        $apiLevels = if ($apiLevelsInput -ne "") {
-          $apiLevelsInput | ConvertFrom-Json
-        } else {
-          @(23, 24, 25, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36)
+
+        if ([string]::IsNullOrWhiteSpace($apiLevelsInput)) {
+          $apiLevelsInput = '[23, 24, 25, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36]'
         }
-        
-        # Add workload-required API levels if not already in the list
-        foreach ($dotnetVersion in $workloadApiLevels.PSObject.Properties.Name) {
-          $workloadApiLevel = $workloadApiLevels.$dotnetVersion
-          if ($workloadApiLevel -notin $apiLevels) {
-            $apiLevels += $workloadApiLevel
-            Write-Host "Added workload-required API level $workloadApiLevel for .NET $dotnetVersion"
-          }
-        }
-        
-        # Sort API levels for consistent output
-        $apiLevels = $apiLevels | Sort-Object
-        
-        Write-Host "Using .NET versions: $($dotnetVersions -join ', ')"
+
+        $apiLevels = @($apiLevelsInput | ConvertFrom-Json | Sort-Object -Unique)
         Write-Host "Using API levels: $($apiLevels -join ', ')"
-        
-        # Create matrix combinations
-        $matrix = @()
-        foreach ($dotnetVersion in $dotnetVersions) {
-          foreach ($apiLevel in $apiLevels) {
-            $matrix += @{
-              dotnet_version = $dotnetVersion
-              android_api_level = $apiLevel
-            }
+
+        $matrix = foreach ($apiLevel in $apiLevels) {
+          @{
+            android_api_level = $apiLevel
           }
         }
-        
-        # Convert to JSON format for GitHub Actions
-        $matrixJson = @{ include = $matrix } | ConvertTo-Json -Compress -Depth 3
+
+        $matrixJson = @{ include = @($matrix) } | ConvertTo-Json -Compress -Depth 3
         Write-Host "Matrix: $matrixJson"
         echo "matrix=$matrixJson" >> $env:GITHUB_OUTPUT
 
-  determine-matrix:
-    runs-on: ubuntu-latest
-    needs: get-workload-info
-    outputs:
-      matrix: ${{ needs.get-workload-info.outputs.matrix }}
-    steps:
-      - name: 📋 Pass Through Matrix
-        run: |
-          echo "Using matrix: ${{ needs.get-workload-info.outputs.matrix }}"
-
   build:
-    needs: [get-workload-info, determine-matrix]
-    name: 🐋 Android ${{ matrix.android_api_level }} Emulator (.NET ${{ matrix.dotnet_version }})
+    needs: determine-matrix
+    name: 🐋 Android ${{ matrix.android_api_level }} Emulator
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.determine-matrix.outputs.matrix) }}
 
     steps:
@@ -181,38 +83,35 @@ jobs:
       shell: pwsh
       working-directory: ./docker/test/
       run: |
-        # Get short Git SHA for unique build tagging
         $buildSha = git rev-parse --short=8 HEAD
         Write-Host "Build SHA: $buildSha"
         Write-Host ""
 
-        # Build arguments
         $buildArgs = @{
-          AndroidSdkApiLevel  = "${{ matrix.android_api_level }}"
-          Version             = "${{ github.run_id }}"
-          BuildSha            = $buildSha
-          Load                = $true
+          AndroidSdkApiLevel = "${{ matrix.android_api_level }}"
+          Version            = "${{ github.run_id }}"
+          BuildSha           = $buildSha
+          Load               = $true
         }
 
         if ("${{ github.ref }}" -eq "refs/heads/main") {
           $buildArgs.Push = $true
         }
 
-        # Add workload set version if specified
-        if ("${{ needs.get-workload-info.outputs.workload-set-version }}" -ne "") {
-          $buildArgs.WorkloadSetVersion = "${{ needs.get-workload-info.outputs.workload-set-version }}"
+        if ("${{ github.event_name }}" -eq "repository_dispatch") {
+          $appiumVersion = '${{ github.event.client_payload.appium_version }}'
+          $appiumDriverVersion = '${{ github.event.client_payload.appium_uiautomator2_driver_version }}'
+        } else {
+          $appiumVersion = '${{ inputs.appium_version }}'
+          $appiumDriverVersion = '${{ inputs.appium_uiautomator2_driver_version }}'
         }
 
-        # Add .NET version from matrix
-        $buildArgs.DotnetVersion = "${{ matrix.dotnet_version }}"
-
-        # Add Appium versions if specified
-        if ("${{ inputs.appium_version }}" -ne "") {
-          $buildArgs.AppiumVersion = "${{ inputs.appium_version }}"
+        if (-not [string]::IsNullOrWhiteSpace($appiumVersion)) {
+          $buildArgs.AppiumVersion = $appiumVersion
         }
 
-        if ("${{ inputs.appium_uiautomator2_driver_version }}" -ne "") {
-          $buildArgs.AppiumUIAutomator2DriverVersion = "${{ inputs.appium_uiautomator2_driver_version }}"
+        if (-not [string]::IsNullOrWhiteSpace($appiumDriverVersion)) {
+          $buildArgs.AppiumUIAutomator2DriverVersion = $appiumDriverVersion
         }
 
         ./build.ps1 @buildArgs
@@ -223,14 +122,13 @@ jobs:
       run: |
         BUILD_SHA=$(git rev-parse --short=8 HEAD)
 
-        echo "## 📱 Android ${{ matrix.android_api_level }} Emulator — .NET ${{ steps.build.outputs.dotnet_version || matrix.dotnet_version }}" >> $GITHUB_STEP_SUMMARY
+        echo "## 📱 Android ${{ matrix.android_api_level }} Emulator" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Installed Software Versions" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "| Component | Version |" >> $GITHUB_STEP_SUMMARY
         echo "|-----------|---------|" >> $GITHUB_STEP_SUMMARY
-        echo "| .NET Runtime | ${{ steps.build.outputs.dotnet_version || matrix.dotnet_version }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Workload Set | ${{ steps.build.outputs.workload_set_version || 'auto-detected' }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| .NET Runtime Base | ${{ steps.build.outputs.dotnet_runtime_image_tag || '10.0-resolute' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Android SDK API Level | ${{ steps.build.outputs.android_api_level || matrix.android_api_level }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Android Build Tools | ${{ steps.build.outputs.android_build_tools || '—' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Android Cmdline Tools | ${{ steps.build.outputs.android_cmdline_tools || '—' }} |" >> $GITHUB_STEP_SUMMARY
@@ -242,7 +140,6 @@ jobs:
         echo "| Build SHA | \`${BUILD_SHA}\` |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        # Image tags
         TAGS="${{ steps.build.outputs.image_tags }}"
         if [ -n "$TAGS" ]; then
           echo "### Image Tags" >> $GITHUB_STEP_SUMMARY
@@ -262,4 +159,3 @@ jobs:
           echo "docker run --device /dev/kvm -p 4723:4723 -p 5554:5554 -p 5555:5555 $FIRST_TAG" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
         fi
-

--- a/.github/workflows/check-workload-updates.yml
+++ b/.github/workflows/check-workload-updates.yml
@@ -167,8 +167,8 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          console.log('Triggering build-emulators workflow - workload update(s) detected');
-          console.log('Each .NET version (10.0 and 11.0) will auto-detect its appropriate workload version');
+          console.log('Triggering build-emulators workflow to refresh emulator images');
+          console.log('Emulator images build once per Android API level and are independent of .NET workload versions');
 
           try {
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -170,8 +170,11 @@ jobs:
           }
         }
         else {
+          $emulatorDotnetVersion = $dotnetVersions[0]
           foreach ($dotnetVersion in $dotnetVersions) {
-            $matrix += New-MatrixEntry -DotnetVersion $dotnetVersion -Platform "linux" -RunnerOs "ubuntu-latest" -BuildTest 'true' -AndroidApiLevel '35'
+            $buildTest = if ($dotnetVersion -eq $emulatorDotnetVersion) { 'true' } else { 'false' }
+            $androidApiLevel = if ($buildTest -eq 'true') { '35' } else { '' }
+            $matrix += New-MatrixEntry -DotnetVersion $dotnetVersion -Platform "linux" -RunnerOs "ubuntu-latest" -BuildTest $buildTest -AndroidApiLevel $androidApiLevel
             $matrix += New-MatrixEntry -DotnetVersion $dotnetVersion -Platform "windows" -RunnerOs "windows-2025"
           }
         }

--- a/README.md
+++ b/README.md
@@ -122,16 +122,12 @@ maui-containers/maui-macos:tahoe-dotnet11.0-preview4-workloads11.0.100-preview.4
 
 #### Emulator/Test Images (includes Android API level)
 ```
-# Android 35 with .NET 10.0
-maui-containers/maui-emulator-linux:android35-dotnet10.0
-maui-containers/maui-emulator-linux:android35-dotnet10.0-workloads10.0.300.3
+# Android 35 emulator
+maui-containers/maui-emulator-linux:android35
+maui-containers/maui-emulator-linux:android35-vsha256abc
 
-# Android 36 with .NET 11.0 Preview
-maui-containers/maui-emulator-linux:android36-dotnet11.0-preview
-maui-containers/maui-emulator-linux:android36-dotnet11.0-preview4
-maui-containers/maui-emulator-linux:android36-dotnet11.0-preview-workloads11.0.100-preview.4.26261.2
-maui-containers/maui-emulator-linux:android36-dotnet11.0-preview-workloads11.0.1xx
-maui-containers/maui-emulator-linux:android36-dotnet11.0-preview4-workloads11.0.100-preview.4.26261.2
+# Compatibility alias for existing consumers
+maui-containers/maui-emulator-linux:android35-dotnet10.0
 ```
 
 ### Platform Identifiers
@@ -239,7 +235,7 @@ docker run \
     -p 5554:5554 \
     -p 5555:5555 \
     -p 4723:4723 \
-    maui-containers/maui-emulator-linux:android35-dotnet10.0
+    maui-containers/maui-emulator-linux:android35
 ```
 
 > NOTE: Ports are mapped for the emulator, ADB, and Appium in this example.
@@ -294,7 +290,7 @@ docker run \
     -e EMULATOR_SNAPSHOT_MODE=save \
     -v emulator-avd:/home/mauiusr/.android/avd \
     -p 4723:4723 \
-    maui-containers/maui-emulator-linux:android35-dotnet10.0
+    maui-containers/maui-emulator-linux:android35
 ```
 
 **Reuse the snapshot (subsequent runs):**
@@ -305,7 +301,7 @@ docker run \
     -e EMULATOR_SNAPSHOT_MODE=load \
     -v emulator-avd:/home/mauiusr/.android/avd \
     -p 4723:4723 \
-    maui-containers/maui-emulator-linux:android35-dotnet10.0
+    maui-containers/maui-emulator-linux:android35
 ```
 
 > **Caution:** Snapshot reuse may leak state between test runs. Keep it opt-in and use the default `none` mode for CI pipelines that require isolation.
@@ -323,8 +319,8 @@ Use `docker inspect --format='{{.State.Health.Status}}'` or wait for `healthy` s
 Use `docker/test/run.ps1` for a quick local launch:
 
 ```powershell
-# Default: API 35, .NET 10.0
-pwsh ./docker/test/run.ps1 -AndroidSdkApiLevel 35 -DotnetVersion 10.0
+# Default: API 35
+pwsh ./docker/test/run.ps1 -AndroidSdkApiLevel 35
 
 # With runtime options
 pwsh ./docker/test/run.ps1 -AndroidSdkApiLevel 35 -DisableSpellchecker -EnableHwKeyboard
@@ -332,16 +328,16 @@ pwsh ./docker/test/run.ps1 -AndroidSdkApiLevel 35 -DisableSpellchecker -EnableHw
 
 ### Variants
 
-Each Android API Level (23 through latest) has its own image variant.  You can specify different ones to use by the tag name (eg: `maui-emulator-linux:android23-dotnet10.0` or `maui-emulator-linux:android35-dotnet10.0`).
+Each Android API Level (23 through latest) has its own image variant. You can specify different ones to use by the tag name (eg: `maui-emulator-linux:android23` or `maui-emulator-linux:android35`). The image uses a .NET runtime base internally for tooling, but emulator variants are not split by .NET or MAUI workload version.
 
-![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android35-dotnet10.0?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
+![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android35?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
 
 <details>
 
 <summary>Show Active Variant Examples...</summary>
 
-- ![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android35-dotnet10.0?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
-- ![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android36-dotnet11.0-preview?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
+- ![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android35?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
+- ![Docker Image Version (tag)](https://img.shields.io/docker/v/mauicontainers/maui-emulator-linux/android36?link=https%3A%2F%2Fhub.docker.com%2Fr%2Fmauicontainers%2Fmaui-emulator-linux%2Ftags)
  
 </details>
 

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -32,9 +32,9 @@ ARG DOTNET_RUNTIME_IMAGE_TAG=10.0-resolute
 
 ARG JDK_MAJOR_VERSION=21
 ARG ANDROID_SDK_API_LEVEL=35
-ARG ANDROID_SDK_BUILD_TOOLS_VERSION=33.0.3
-ARG ANDROID_SDK_CMDLINE_TOOLS_VERSION=13.0
-ARG ANDROID_SDK_AVD_DEVICE_TYPE="Nexus 5X"
+ARG ANDROID_SDK_BUILD_TOOLS_VERSION=36.0.0
+ARG ANDROID_SDK_CMDLINE_TOOLS_VERSION=19.0
+ARG ANDROID_SDK_AVD_DEVICE_TYPE="Nexus 5"
 ARG ANDROID_SDK_AVD_SYSTEM_IMAGE_TYPE=google_apis
 ARG APPIUM_VERSION=2.0.12
 ARG APPIUM_UIAUTOMATOR2_DRIVER_VERSION=3.0.8
@@ -123,7 +123,7 @@ RUN apt-get update && apt-get install -y \
     cpu-checker \
     ffmpeg \
     tree \
-    qemu-kvm qemu-utils bridge-utils libvirt-daemon-system libvirt-daemon qemu-system virt-manager virtinst libvirt-clients \
+    qemu-system-x86 qemu-utils bridge-utils libvirt-daemon-system libvirt-daemon qemu-system virt-manager virtinst libvirt-clients \
     socat supervisor \
     && apt autoremove -y \
     && apt clean all \

--- a/docker/test/build.ps1
+++ b/docker/test/build.ps1
@@ -7,8 +7,15 @@ Param(
     [String]$DockerPlatform="linux/amd64",
     [String]$AndroidSdkApiLevel=35,
     [String]$Version="latest",
-    [String]$WorkloadSetVersion="",
     [String]$DotnetVersion="10.0",
+    [String]$DotnetSdkImageTag="",
+    [String]$DotnetRuntimeImageTag="",
+    [String]$AndroidSdkBuildToolsVersion="36.0.0",
+    [String]$AndroidSdkCmdLineToolsVersion="19.0",
+    [String]$AndroidAvdDeviceType="Nexus 5",
+    [String]$AndroidAvdSystemImageType="google_apis",
+    [String]$JdkMajorVersion="21",
+    [String]$WorkloadSetVersion="",
     [String]$AppiumVersion="",
     [String]$AppiumUIAutomator2DriverVersion="",
     [String]$BuildSha="",
@@ -24,8 +31,7 @@ if ($DockerPlatform.StartsWith('linux/')) {
     exit 1
 }
 
-# Import common functions for Appium version detection
-# NOTE: We only use this for Get-LatestAppiumVersions, not for workload detection
+# Import common functions for Appium version detection and .NET base image tags.
 $commonFunctionsPath = Join-Path -Path $PSScriptRoot -ChildPath "..\..\common-functions.ps1" -Resolve -ErrorAction SilentlyContinue
 
 if ($commonFunctionsPath -and (Test-Path -Path $commonFunctionsPath -PathType Leaf)) {
@@ -66,122 +72,77 @@ if ([string]::IsNullOrEmpty($AppiumVersion) -or [string]::IsNullOrEmpty($AppiumU
     Write-Host "  UIAutomator2 Driver: $AppiumUIAutomator2DriverVersion"
 }
 
-# Default Android SDK component versions (will be overridden by workload detection)
-# These values are used as fallbacks if workload detection fails
-$androidBuildToolsVersion = "35.0.0"
-$androidCmdLineToolsVersion = "13.0"
-$androidJdkMajorVersion = "21"
-$androidAvdSystemImageType = "google_apis"
-$androidAvdDeviceType = "Nexus 5X"
-
-# Get comprehensive workload information with a single call
-Write-Host "Getting workload information for Android SDK dependencies..."
-$workloadInfo = Get-WorkloadInfo -DotnetVersion $DotnetVersion -WorkloadSetVersion $WorkloadSetVersion -IncludeAndroid -DockerPlatform $DockerPlatform
-
-if (-not $workloadInfo) {
-    Write-Error "Failed to get workload information."
-    exit 1
+# Emulator images are not MAUI build images, so keep Android SDK inputs explicit
+# instead of coupling emulator tags and builds to .NET workload set versions.
+if (-not [string]::IsNullOrWhiteSpace($WorkloadSetVersion)) {
+    Write-Warning "WorkloadSetVersion is ignored for emulator images. Android SDK components are configured directly."
 }
 
-# Extract Android-specific information
-$androidWorkload = $workloadInfo.Workloads["Microsoft.NET.Sdk.Android"]
-if (-not $androidWorkload) {
-    Write-Error "Could not find Android workload in the workload set."
-    exit 1
+$requiredSettings = @{
+    AndroidSdkBuildToolsVersion   = $AndroidSdkBuildToolsVersion
+    AndroidSdkCmdLineToolsVersion = $AndroidSdkCmdLineToolsVersion
+    AndroidAvdDeviceType          = $AndroidAvdDeviceType
+    AndroidAvdSystemImageType     = $AndroidAvdSystemImageType
+    JdkMajorVersion               = $JdkMajorVersion
 }
 
-# Extract Android details if available
-$androidDetails = $androidWorkload.Details
-if (-not $androidDetails) {
-    Write-Error "Could not extract Android details from workload."
-    exit 1
-}
-
-Write-Host "Android workload details retrieved successfully:"
-Write-Host "  API Level: $($androidDetails.ApiLevel)"
-Write-Host "  Build Tools Version: $($androidDetails.BuildToolsVersion)"
-Write-Host "  Command Line Tools Version: $($androidDetails.CmdLineToolsVersion)"
-Write-Host "  JDK Major Version: $($androidDetails.JdkMajorVersion)"
-Write-Host "  System Image Type: $($androidDetails.SystemImageType)"
-Write-Host "  AVD Device Type: $($androidDetails.AvdDeviceType)"
-
-# Use workload-detected values for Android SDK components (override hardcoded values)
-$androidBuildToolsVersion = $androidDetails.BuildToolsVersion
-$androidCmdLineToolsVersion = $androidDetails.CmdLineToolsVersion
-$androidJdkMajorVersion = $androidDetails.JdkMajorVersion
-$androidAvdSystemImageType = $androidDetails.SystemImageType
-$androidAvdDeviceType = $androidDetails.AvdDeviceType
-
-if ([string]::IsNullOrWhiteSpace($androidAvdSystemImageType)) {
-    $androidAvdSystemImageType = "google_apis"
-    Write-Warning "Android workload did not specify an AVD system image type; using fallback: $androidAvdSystemImageType"
-}
-
-if ([string]::IsNullOrWhiteSpace($androidAvdDeviceType)) {
-    $androidAvdDeviceType = "Nexus 5X"
-    Write-Warning "Android workload did not specify an AVD device type; using fallback: $androidAvdDeviceType"
-}
-
-# Extract the dotnet command version for Docker tags
-$dotnetCommandWorkloadSetVersion = $workloadInfo.DotnetCommandWorkloadSetVersion
-$dotnetImageTags = Get-DotnetContainerImageTags -DotnetVersion $DotnetVersion -DockerPlatform $DockerPlatform
-Write-Host "Using .NET SDK image tag: $($dotnetImageTags.Sdk)"
-Write-Host "Using .NET runtime image tag: $($dotnetImageTags.Runtime)"
-
-# Determine which Android SDK API level to use
-# Use the parameter provided, which could be from the matrix or a specific override
-Write-Host "Using Android SDK API Level: $AndroidSdkApiLevel (from parameter/matrix)"
-Write-Host "Workload default API Level: $($androidDetails.ApiLevel) (will be available in the built image)"
-
-# Build tags following the unified naming scheme:
-# - android{XX}-dotnet{X.Y} for stable, android{XX}-dotnet{X.Y}-{prerelease} for prerelease channels
-# - android{XX}-dotnet{X.Y}-{prereleaseN} for a specific prerelease wave
-# - android{XX}-dotnet{tag}-workloads{X.Y.Z} - Specific workload version
-# - android{XX}-dotnet{specific-tag}-workloads{X.Y.Z}-v{sha} - SHA-pinned version (optional)
-# If Version is not "latest", also add a custom version tag
-$tags = @()
-$workloadBandTagVersion = Get-WorkloadBandTag -WorkloadVersion $dotnetCommandWorkloadSetVersion
-$dotnetTagPrefixInfo = Get-DotnetTagPrefixInfo -DotnetVersion $DotnetVersion -WorkloadVersion $dotnetCommandWorkloadSetVersion -Prefix "android${AndroidSdkApiLevel}-"
-
-# 1. android{XX}-dotnet{tag} tag (this is the "latest" for this .NET version/channel + API level)
-$dotnetTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Channel)"
-$tags += $dotnetTag
-
-# 2. Optional: android{XX}-dotnet{specific-prerelease} tag (e.g. android36-dotnet11.0-preview4)
-if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
-    $specificDotnetTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)"
-    $tags += $specificDotnetTag
-}
-
-# 3. android{XX}-dotnet{tag}-workloads{X.Y.Z} tag
-$workloadTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Channel)-workloads${dotnetCommandWorkloadSetVersion}"
-$tags += $workloadTag
-
-# 4. Optional: prerelease rolling workload band tag
-if ($dotnetTagPrefixInfo.IsPrerelease -and $workloadBandTagVersion) {
-    $workloadBandTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Channel)-workloads${workloadBandTagVersion}"
-    if ($tags -notcontains $workloadBandTag) {
-        $tags += $workloadBandTag
+foreach ($setting in $requiredSettings.GetEnumerator()) {
+    if ([string]::IsNullOrWhiteSpace($setting.Value)) {
+        Write-Error "$($setting.Key) is required."
+        exit 1
     }
 }
 
-# 5. Optional: android{XX}-dotnet{specific-prerelease}-workloads{X.Y.Z} tag
-if ($dotnetTagPrefixInfo.Specific -ne $dotnetTagPrefixInfo.Channel) {
-    $specificWorkloadTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)-workloads${dotnetCommandWorkloadSetVersion}"
-    $tags += $specificWorkloadTag
+$androidBuildToolsVersion = $AndroidSdkBuildToolsVersion
+$androidCmdLineToolsVersion = $AndroidSdkCmdLineToolsVersion
+$androidJdkMajorVersion = $JdkMajorVersion
+$androidAvdSystemImageType = $AndroidAvdSystemImageType
+$androidAvdDeviceType = $AndroidAvdDeviceType
+
+$dotnetImageTags = Get-DotnetContainerImageTags -DotnetVersion $DotnetVersion -DockerPlatform $DockerPlatform
+
+if (-not [string]::IsNullOrWhiteSpace($DotnetSdkImageTag)) {
+    $dotnetImageTags.Sdk = $DotnetSdkImageTag
 }
 
-# 6. Optional: android{XX}-dotnet{specific-tag}-workloads{X.Y.Z}-v{sha} tag
+if (-not [string]::IsNullOrWhiteSpace($DotnetRuntimeImageTag)) {
+    $dotnetImageTags.Runtime = $DotnetRuntimeImageTag
+}
+
+Write-Host "Using .NET SDK image tag: $($dotnetImageTags.Sdk)"
+Write-Host "Using .NET runtime image tag: $($dotnetImageTags.Runtime)"
+
+Write-Host "Using Android SDK settings:"
+Write-Host "  API Level: $AndroidSdkApiLevel"
+Write-Host "  Build Tools Version: $androidBuildToolsVersion"
+Write-Host "  Command Line Tools Version: $androidCmdLineToolsVersion"
+Write-Host "  JDK Major Version: $androidJdkMajorVersion"
+Write-Host "  System Image Type: $androidAvdSystemImageType"
+Write-Host "  AVD Device Type: $androidAvdDeviceType"
+
+# Build tags. The API-level tag is primary; dotnet-suffixed tags are kept as
+# compatibility aliases for existing consumers.
+$tags = @()
+$primaryTag = "${DockerRepository}:android${AndroidSdkApiLevel}"
+$legacyDotnetTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}"
+$tags += $primaryTag
+$tags += $legacyDotnetTag
+
 if ($BuildSha) {
-    $shaTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)-workloads${dotnetCommandWorkloadSetVersion}-v${BuildSha}"
+    $shaTag = "${DockerRepository}:android${AndroidSdkApiLevel}-v${BuildSha}"
+    $legacyShaTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}-v${BuildSha}"
     $tags += $shaTag
+    $tags += $legacyShaTag
 }
 
-# 7. Optional: Custom version tag (for PR builds, etc.)
 if ($Version -ne "latest") {
-    $customTag = "${DockerRepository}:$($dotnetTagPrefixInfo.Specific)-${Version}"
+    $customTag = "${DockerRepository}:android${AndroidSdkApiLevel}-${Version}"
+    $legacyCustomTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet${DotnetVersion}-${Version}"
     $tags += $customTag
+    $tags += $legacyCustomTag
 }
+
+$tags = $tags | Select-Object -Unique
 
 Write-Host "Docker tags that will be created:"
 foreach ($tag in $tags) {
@@ -201,10 +162,10 @@ $commonArgs = @(
     "--build-arg", "DOTNET_VERSION=$DotnetVersion",
     "--build-arg", "DOTNET_SDK_IMAGE_TAG=$($dotnetImageTags.Sdk)",
     "--build-arg", "DOTNET_RUNTIME_IMAGE_TAG=$($dotnetImageTags.Runtime)",
-    # Dynamic OCI labels with resolved build-time values
-    "--label", "org.opencontainers.image.version=android$AndroidSdkApiLevel-$dotnetCommandWorkloadSetVersion",
+    "--label", "org.opencontainers.image.version=android$AndroidSdkApiLevel",
     "--label", "org.opencontainers.image.created=$(Get-Date -Format 'o')",
     "--label", "org.opencontainers.image.revision=$BuildSha",
+    "--label", "dev.maui-containers.dotnet-base=$DotnetVersion",
     "-f", "Dockerfile",
     "."
 )
@@ -246,7 +207,6 @@ try {
         "dotnet_version=$DotnetVersion" >> $env:GITHUB_OUTPUT
         "dotnet_sdk_image_tag=$($dotnetImageTags.Sdk)" >> $env:GITHUB_OUTPUT
         "dotnet_runtime_image_tag=$($dotnetImageTags.Runtime)" >> $env:GITHUB_OUTPUT
-        "workload_set_version=$dotnetCommandWorkloadSetVersion" >> $env:GITHUB_OUTPUT
         "android_api_level=$AndroidSdkApiLevel" >> $env:GITHUB_OUTPUT
         "android_build_tools=$androidBuildToolsVersion" >> $env:GITHUB_OUTPUT
         "android_cmdline_tools=$androidCmdLineToolsVersion" >> $env:GITHUB_OUTPUT

--- a/docker/test/run.ps1
+++ b/docker/test/run.ps1
@@ -1,6 +1,6 @@
 Param(
     [String]$AndroidSdkApiLevel = 35,
-    [String]$DotnetVersion = "10.0",
+    [String]$DotnetVersion = "",
     [String]$DockerRepository = "maui-containers/maui-emulator-linux",
     [String]$AdbKeyFolder = "$env:USERPROFILE/.android",
     [Int]$AdbPortMapping = 5555,
@@ -19,12 +19,8 @@ Param(
     [String]$AvdName = ""
 )
 
-$commonFunctionsPath = Join-Path -Path $PSScriptRoot -ChildPath "..\..\common-functions.ps1" -Resolve -ErrorAction SilentlyContinue
-if ($commonFunctionsPath -and (Test-Path -Path $commonFunctionsPath -PathType Leaf)) {
-    . $commonFunctionsPath
-} else {
-    Write-Error "Could not find common functions file at expected path: ..\..\common-functions.ps1"
-    exit 1
+if (-not [string]::IsNullOrWhiteSpace($DotnetVersion)) {
+    Write-Warning "DotnetVersion is ignored for emulator images. Use android${AndroidSdkApiLevel} tags."
 }
 
 $runArgs = @(
@@ -67,8 +63,7 @@ if ($AvdName -ne "") {
     $runArgs += "-e", "AVD_NAME=$AvdName"
 }
 
-$dotnetImageTags = Get-DotnetContainerImageTags -DotnetVersion $DotnetVersion -DockerPlatform "linux/amd64"
-$imageTag = "${DockerRepository}:android${AndroidSdkApiLevel}-dotnet$($dotnetImageTags.ImageVersion)"
+$imageTag = "${DockerRepository}:android${AndroidSdkApiLevel}"
 $runArgs += $imageTag
 
 Write-Host "Starting emulator container: docker $($runArgs -join ' ')"


### PR DESCRIPTION
The Android emulator image is meant to provide Appium and Android emulator runtime support, not a MAUI build environment. Building it once per .NET/workload version doubled the matrix and exposed it to workload-tag churn that does not matter for emulator usage.

This change makes emulator builds one-per-Android-API-level, keeps the .NET runtime base as an internal implementation detail, and preserves `androidXX-dotnet10.0` compatibility aliases for existing consumers. It also replaces the obsolete `qemu-kvm` package with `qemu-system-x86` so Ubuntu resolute-based images can install QEMU successfully.